### PR TITLE
Add lambda-ecr module to main infrastructure

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -214,6 +214,13 @@ module "serverless_storage" {
   ]
 }
 
+# Lambda ECR Module - Creates ECR repositories for Lambda deployment
+module "lambda_ecr" {
+  source = "./modules/lambda-ecr"
+
+  tags = var.tags
+}
+
 # DNS Module
 module "dns" {
   source = "./modules/dns"

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -184,6 +184,17 @@ output "serverless_lambda_policy_arns" {
   value       = module.serverless_storage.lambda_s3_policy_arns
 }
 
+# Lambda ECR Outputs
+output "geolambda_repository_url" {
+  description = "URL of the geolambda ECR repository"
+  value       = module.lambda_ecr.geolambda_repository_url
+}
+
+output "lambda_repository_url" {
+  description = "URL of the Lambda ECR repository"
+  value       = module.lambda_ecr.lambda_repository_url
+}
+
 # Summary output
 output "deployment_summary" {
   description = "Complete deployment summary"


### PR DESCRIPTION
Added lambda-ecr module to create ECR repositories for Lambda deployment. This enables the GitHub Actions workflow to push geolambda base images and coalition-builder-lambda application images to ECR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)