### PR TITLE
fix(ci): pass TF_VAR_prefix from GitHub environment to Terraform

### DIFF
--- a/.github/workflows/deploy_infra.yml
+++ b/.github/workflows/deploy_infra.yml
@@ -110,6 +110,7 @@ jobs:
       TF_VAR_site_password: ${{ secrets.SITE_PASSWORD }}
       TF_VAR_shared_peering_role_arn: ${{ secrets.SHARED_PEERING_ROLE_ARN }}
       # Variables (from GitHub environment)
+      TF_VAR_prefix: ${{ vars.TF_VAR_PREFIX }}
       TF_VAR_shared_account_id: ${{ vars.SHARED_ACCOUNT_ID }}
       TF_VAR_github_repo: ${{ vars.REPO_FULL_NAME }}
       TF_VAR_domain_name: ${{ vars.TF_VAR_DOMAIN_NAME }}

--- a/.github/workflows/deploy_infra.yml
+++ b/.github/workflows/deploy_infra.yml
@@ -127,10 +127,14 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Validate AWS Account ID
+      - name: Validate required variables
         run: |
           if [ -z "${{ vars.AWS_ACCOUNT_ID }}" ]; then
             echo "::error::AWS_ACCOUNT_ID variable is not set in the '${{ needs.determine-environment.outputs.environment }}' GitHub environment"
+            exit 1
+          fi
+          if [ -z "${{ vars.TF_VAR_PREFIX }}" ]; then
+            echo "::error::TF_VAR_PREFIX variable is not set in the '${{ needs.determine-environment.outputs.environment }}' GitHub environment"
             exit 1
           fi
 


### PR DESCRIPTION
## Summary
- Adds `TF_VAR_prefix` to the Terraform CI/CD workflow, sourced from the `TF_VAR_PREFIX` GitHub environment variable
- Prevents silent resource renames when the hardcoded default doesn't match deployed infrastructure

## Test plan
- [ ] Verify `TF_VAR_PREFIX` is set in dev, prod, and shared GitHub environments
- [ ] `terraform plan` uses the environment variable value over the default

🤖 Generated with [Claude Code](https://claude.com/claude-code)