### PR TITLE
Add Google Workspace MX record

### DIFF
--- a/terraform/environments/shared/main.tf
+++ b/terraform/environments/shared/main.tf
@@ -121,6 +121,15 @@ resource "aws_route53_record" "apex" {
   records = [var.vercel_ip]
 }
 
+# Apex domain -> Google Workspace (inbound email)
+resource "aws_route53_record" "google_workspace_mx" {
+  zone_id = aws_route53_zone.main.zone_id
+  name    = var.domain_name
+  type    = "MX"
+  ttl     = 300
+  records = ["1 smtp.google.com"]
+}
+
 resource "aws_route53_record" "www" {
   zone_id = aws_route53_zone.main.zone_id
   name    = "www.${var.domain_name}"


### PR DESCRIPTION
## Summary

- add a Route 53 MX record for `landandbay.org`
- route inbound email to Google Workspace at priority 1 via `smtp.google.com`
- preserve the existing Vercel web and Amazon SES outbound-email records

## Why

`landandbay.org` has no MX record. SMTP senders therefore fall back to the apex A record (`76.76.21.21`), which serves the Vercel website and does not accept SMTP connections. Messages to `@landandbay.org` consequently time out and bounce.

## Impact

Applying the shared Terraform environment will publish the MX record so the activated Google Workspace mailbox can receive email after DNS propagation. Previously bounced messages must be resent.

## Validation

- `terraform fmt -check -recursive terraform`
- `terraform -chdir=terraform/environments/shared init -backend=false -input=false`
- `terraform -chdir=terraform/environments/shared validate`
- `tflint --chdir=terraform/environments/shared --init`
- `tflint --chdir=terraform/environments/shared`