### PR TITLE
Fix Terraform deployment routing

### DIFF
--- a/.github/scripts/list_terraform_changed_paths.sh
+++ b/.github/scripts/list_terraform_changed_paths.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+readonly CORRELATION_ID="github-run-${GITHUB_RUN_ID:-local}"
+readonly ZERO_SHA='0000000000000000000000000000000000000000'
+
+fail_changed_path_listing() {
+  local error_class="$1"
+  local message="$2"
+
+  printf 'stage=changed-path-discovery correlation=%s outcome=failure error_class=%s message=%q\n' \
+    "${CORRELATION_ID}" "${error_class}" "${message}" >&2
+  exit 1
+}
+
+list_changed_paths() {
+  local before_sha="$1"
+  local after_sha="$2"
+
+  if [[ "${before_sha}" == "${ZERO_SHA}" ]]; then
+    fail_changed_path_listing 'MissingBaseCommit' \
+      'cannot select Terraform environments without a base commit'
+  fi
+
+  if ! git diff --no-renames --name-only "${before_sha}" "${after_sha}"; then
+    fail_changed_path_listing 'GitDiffError' \
+      "could not compare commits ${before_sha} and ${after_sha}"
+  fi
+
+  printf 'stage=changed-path-discovery correlation=%s outcome=success\n' \
+    "${CORRELATION_ID}" >&2
+}
+
+main() {
+  if (( $# != 2 )); then
+    fail_changed_path_listing 'InvalidArguments' \
+      'before and after commit SHAs are required'
+  fi
+
+  list_changed_paths "$1" "$2"
+}
+
+main "$@"

--- a/.github/scripts/select_terraform_environments.sh
+++ b/.github/scripts/select_terraform_environments.sh
@@ -48,9 +48,7 @@ classify_terraform_change() {
     terraform/environments/shared/*) printf 'shared\n' ;;
     terraform/environments/prod/*) printf 'prod\n' ;;
     terraform/environments/dev/*) printf 'dev\n' ;;
-    terraform/modules/* | terraform/scripts/setup_remote_state.sh | \
-      terraform/backend.tf | terraform/main.tf | terraform/outputs.tf | \
-      terraform/variables.tf | terraform/versions.tf)
+    terraform/modules/* | terraform/scripts/setup_remote_state.sh)
       printf 'all\n'
       ;;
     *) printf 'none\n' ;;

--- a/.github/scripts/select_terraform_environments.sh
+++ b/.github/scripts/select_terraform_environments.sh
@@ -1,0 +1,139 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+readonly CORRELATION_ID="github-run-${GITHUB_RUN_ID:-local}"
+
+fail_selection() {
+  local error_class="$1"
+  local message="$2"
+
+  printf 'stage=environment-selection correlation=%s outcome=failure error_class=%s message=%q\n' \
+    "${CORRELATION_ID}" "${error_class}" "${message}" >&2
+  exit 1
+}
+
+emit_selected_environments() {
+  local json='['
+  local separator=''
+  local environment
+
+  for environment in "$@"; do
+    json+="${separator}\"${environment}\""
+    separator=','
+  done
+
+  printf '%s]\n' "${json}"
+}
+
+select_manual_environment() {
+  local requested_environment="$1"
+
+  case "${requested_environment}" in
+    shared | prod | dev) ;;
+    *)
+      fail_selection 'InvalidEnvironment' \
+        "workflow_dispatch environment must be shared, prod, or dev"
+      ;;
+  esac
+
+  emit_selected_environments "${requested_environment}"
+}
+
+classify_terraform_change() {
+  local changed_path="$1"
+
+  case "${changed_path}" in
+    terraform/environments/shared/*) printf 'shared\n' ;;
+    terraform/environments/prod/*) printf 'prod\n' ;;
+    terraform/environments/dev/*) printf 'dev\n' ;;
+    terraform/modules/* | terraform/scripts/* | \
+      terraform/backend.tf | terraform/main.tf | terraform/outputs.tf | \
+      terraform/variables.tf | terraform/versions.tf | \
+      terraform/terraform.tfvars.example)
+      printf 'all\n'
+      ;;
+    *) printf 'none\n' ;;
+  esac
+}
+
+select_push_environments() {
+  local shared_changed=false
+  local prod_changed=false
+  local dev_changed=false
+  local common_configuration_changed=false
+  local changed_path
+  local change_scope
+
+  for changed_path in "$@"; do
+    change_scope="$(classify_terraform_change "${changed_path}")"
+    case "${change_scope}" in
+      shared)
+        shared_changed=true
+        ;;
+      prod)
+        prod_changed=true
+        ;;
+      dev)
+        dev_changed=true
+        ;;
+      all)
+        common_configuration_changed=true
+        ;;
+    esac
+  done
+
+  if [[ "${common_configuration_changed}" == 'true' ]]; then
+    shared_changed=true
+    prod_changed=true
+    dev_changed=true
+  fi
+
+  local selected_environments=()
+  if [[ "${shared_changed}" == 'true' ]]; then
+    selected_environments+=(shared)
+  fi
+  if [[ "${prod_changed}" == 'true' ]]; then
+    selected_environments+=(prod)
+  fi
+  if [[ "${dev_changed}" == 'true' ]]; then
+    selected_environments+=(dev)
+  fi
+  if [[ "${shared_changed}" == 'false' && \
+    "${prod_changed}" == 'false' && \
+    "${dev_changed}" == 'false' ]]; then
+    emit_selected_environments
+  else
+    emit_selected_environments "${selected_environments[@]}"
+  fi
+}
+
+main() {
+  if (( $# == 0 )); then
+    fail_selection 'MissingEvent' 'GitHub event name is required'
+  fi
+
+  local event_name="$1"
+  local requested_environment="${2:-}"
+  shift
+  if (( $# > 0 )); then
+    shift
+  fi
+
+  case "${event_name}" in
+    workflow_dispatch)
+      select_manual_environment "${requested_environment}"
+      ;;
+    pull_request)
+      printf '["dev"]\n'
+      ;;
+    push)
+      select_push_environments "$@"
+      ;;
+    *)
+      fail_selection 'UnsupportedEvent' "unsupported GitHub event: ${event_name}"
+      ;;
+  esac
+}
+
+main "$@"

--- a/.github/scripts/select_terraform_environments.sh
+++ b/.github/scripts/select_terraform_environments.sh
@@ -44,13 +44,13 @@ classify_terraform_change() {
   local changed_path="$1"
 
   case "${changed_path}" in
+    terraform/*.md) printf 'none\n' ;;
     terraform/environments/shared/*) printf 'shared\n' ;;
     terraform/environments/prod/*) printf 'prod\n' ;;
     terraform/environments/dev/*) printf 'dev\n' ;;
-    terraform/modules/* | terraform/scripts/* | \
+    terraform/modules/* | terraform/scripts/setup_remote_state.sh | \
       terraform/backend.tf | terraform/main.tf | terraform/outputs.tf | \
-      terraform/variables.tf | terraform/versions.tf | \
-      terraform/terraform.tfvars.example)
+      terraform/variables.tf | terraform/versions.tf)
       printf 'all\n'
       ;;
     *) printf 'none\n' ;;

--- a/.github/scripts/test_select_terraform_environments.sh
+++ b/.github/scripts/test_select_terraform_environments.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+SCRIPT_DIRECTORY="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+readonly SCRIPT_DIRECTORY
+SELECTOR="${SCRIPT_DIRECTORY}/select_terraform_environments.sh"
+readonly SELECTOR
+
+assert_selection() {
+  local expected_selection="$1"
+  shift
+
+  local actual_selection
+  actual_selection="$("${SELECTOR}" "$@")"
+
+  if [[ "${actual_selection}" != "${expected_selection}" ]]; then
+    printf 'Expected %s, got %s for: %s\n' \
+      "${expected_selection}" "${actual_selection}" "$*" >&2
+    return 1
+  fi
+}
+
+assert_rejected() {
+  if "${SELECTOR}" "$@" >/dev/null 2>&1; then
+    printf 'Expected selection to fail for: %s\n' "$*" >&2
+    return 1
+  fi
+}
+
+assert_selection '["shared"]' workflow_dispatch shared
+assert_selection '["prod"]' workflow_dispatch prod
+assert_selection '["dev"]' workflow_dispatch dev
+assert_rejected workflow_dispatch invalid
+
+assert_selection '["dev"]' pull_request
+
+assert_selection '["shared"]' push '' terraform/environments/shared/main.tf
+assert_selection '["prod"]' push '' terraform/environments/prod/main.tf
+assert_selection '["dev"]' push '' terraform/environments/dev/main.tf
+assert_selection '["shared","prod","dev"]' push '' \
+  terraform/environments/dev/main.tf \
+  terraform/environments/prod/main.tf \
+  terraform/environments/shared/main.tf
+assert_selection '["shared","prod","dev"]' push '' terraform/modules/networking/main.tf
+assert_selection '["shared","prod","dev"]' push '' terraform/scripts/setup_remote_state.sh
+assert_selection '[]' push '' .github/workflows/deploy_infra.yml
+assert_selection '[]' push '' .github/workflows/deploy_terraform_environment.yml
+assert_selection '[]' push '' .github/scripts/select_terraform_environments.sh
+assert_selection '[]' push '' terraform/tests/modules/networking_test.go
+assert_selection '[]' push '' terraform/README.md
+assert_rejected schedule
+
+printf 'Terraform deployment environment selection tests passed.\n'

--- a/.github/scripts/test_select_terraform_environments.sh
+++ b/.github/scripts/test_select_terraform_environments.sh
@@ -6,6 +6,8 @@ SCRIPT_DIRECTORY="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 readonly SCRIPT_DIRECTORY
 SELECTOR="${SCRIPT_DIRECTORY}/select_terraform_environments.sh"
 readonly SELECTOR
+CHANGED_PATH_LISTER="${SCRIPT_DIRECTORY}/list_terraform_changed_paths.sh"
+readonly CHANGED_PATH_LISTER
 
 assert_selection() {
   local expected_selection="$1"
@@ -22,8 +24,12 @@ assert_selection() {
 }
 
 assert_rejected() {
-  if "${SELECTOR}" "$@" >/dev/null 2>&1; then
-    printf 'Expected selection to fail for: %s\n' "$*" >&2
+  local rejected_command="$1"
+  shift
+
+  if "${rejected_command}" "$@" >/dev/null 2>&1; then
+    printf 'Expected command to reject: %s %s\n' \
+      "${rejected_command}" "$*" >&2
     return 1
   fi
 }
@@ -31,7 +37,7 @@ assert_rejected() {
 assert_selection '["shared"]' workflow_dispatch shared
 assert_selection '["prod"]' workflow_dispatch prod
 assert_selection '["dev"]' workflow_dispatch dev
-assert_rejected workflow_dispatch invalid
+assert_rejected "${SELECTOR}" workflow_dispatch invalid
 
 assert_selection '["dev"]' pull_request
 
@@ -49,6 +55,48 @@ assert_selection '[]' push '' .github/workflows/deploy_terraform_environment.yml
 assert_selection '[]' push '' .github/scripts/select_terraform_environments.sh
 assert_selection '[]' push '' terraform/tests/modules/networking_test.go
 assert_selection '[]' push '' terraform/README.md
-assert_rejected schedule
+assert_rejected "${SELECTOR}" schedule
+
+RENAME_FIXTURE_REPOSITORY="$(mktemp -d "${TMPDIR:-/tmp}/terraform-environment-selection.XXXXXX")"
+readonly RENAME_FIXTURE_REPOSITORY
+trap 'rm -rf -- "${RENAME_FIXTURE_REPOSITORY}"' EXIT
+
+git init --quiet "${RENAME_FIXTURE_REPOSITORY}"
+git -C "${RENAME_FIXTURE_REPOSITORY}" config user.email 'terraform-selection@example.com'
+git -C "${RENAME_FIXTURE_REPOSITORY}" config user.name 'Terraform Selection Test'
+mkdir -p "${RENAME_FIXTURE_REPOSITORY}/terraform/environments/shared"
+printf 'resource "example" "moved" {}\n' \
+  >"${RENAME_FIXTURE_REPOSITORY}/terraform/environments/shared/moved.tf"
+git -C "${RENAME_FIXTURE_REPOSITORY}" add .
+git -C "${RENAME_FIXTURE_REPOSITORY}" commit --quiet -m 'Add shared resource'
+shared_commit="$(git -C "${RENAME_FIXTURE_REPOSITORY}" rev-parse HEAD)"
+readonly shared_commit
+
+mkdir -p "${RENAME_FIXTURE_REPOSITORY}/terraform/environments/prod"
+git -C "${RENAME_FIXTURE_REPOSITORY}" mv \
+  terraform/environments/shared/moved.tf \
+  terraform/environments/prod/moved.tf
+git -C "${RENAME_FIXTURE_REPOSITORY}" commit --quiet -m 'Move resource to prod'
+prod_commit="$(git -C "${RENAME_FIXTURE_REPOSITORY}" rev-parse HEAD)"
+readonly prod_commit
+
+actual_changed_paths="$(
+  cd "${RENAME_FIXTURE_REPOSITORY}"
+  "${CHANGED_PATH_LISTER}" "${shared_commit}" "${prod_commit}"
+)"
+expected_changed_paths=$'terraform/environments/prod/moved.tf\nterraform/environments/shared/moved.tf'
+if [[ "${actual_changed_paths}" != "${expected_changed_paths}" ]]; then
+  printf 'Expected changed paths %q, got %q\n' \
+    "${expected_changed_paths}" "${actual_changed_paths}" >&2
+  exit 1
+fi
+
+(
+  cd "${RENAME_FIXTURE_REPOSITORY}"
+  assert_rejected "${CHANGED_PATH_LISTER}" \
+    '0000000000000000000000000000000000000000' "${prod_commit}"
+  assert_rejected "${CHANGED_PATH_LISTER}" \
+    '1111111111111111111111111111111111111111' "${prod_commit}"
+)
 
 printf 'Terraform deployment environment selection tests passed.\n'

--- a/.github/scripts/test_select_terraform_environments.sh
+++ b/.github/scripts/test_select_terraform_environments.sh
@@ -58,6 +58,11 @@ assert_selection '[]' push '' terraform/README.md
 assert_selection '[]' push '' terraform/modules/database/README.md
 assert_selection '[]' push '' terraform/scripts/bootstrap/test_bootstrap.sh
 assert_selection '[]' push '' terraform/terraform.tfvars.example
+assert_selection '[]' push '' terraform/backend.tf
+assert_selection '[]' push '' terraform/main.tf
+assert_selection '[]' push '' terraform/outputs.tf
+assert_selection '[]' push '' terraform/variables.tf
+assert_selection '[]' push '' terraform/versions.tf
 assert_rejected "${SELECTOR}" schedule
 
 RENAME_FIXTURE_REPOSITORY="$(mktemp -d "${TMPDIR:-/tmp}/terraform-environment-selection.XXXXXX")"

--- a/.github/scripts/test_select_terraform_environments.sh
+++ b/.github/scripts/test_select_terraform_environments.sh
@@ -55,6 +55,9 @@ assert_selection '[]' push '' .github/workflows/deploy_terraform_environment.yml
 assert_selection '[]' push '' .github/scripts/select_terraform_environments.sh
 assert_selection '[]' push '' terraform/tests/modules/networking_test.go
 assert_selection '[]' push '' terraform/README.md
+assert_selection '[]' push '' terraform/modules/database/README.md
+assert_selection '[]' push '' terraform/scripts/bootstrap/test_bootstrap.sh
+assert_selection '[]' push '' terraform/terraform.tfvars.example
 assert_rejected "${SELECTOR}" schedule
 
 RENAME_FIXTURE_REPOSITORY="$(mktemp -d "${TMPDIR:-/tmp}/terraform-environment-selection.XXXXXX")"

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -203,7 +203,11 @@ _Figure 1: Workflow dependency tree showing how push/PR events trigger orchestra
 #### Infrastructure Deployment (`deploy_infra.yml`)
 
 - **Triggered by**: changes to `terraform/` directory on main branch or manual dispatch
-- Manages AWS infrastructure changes using Terraform
+- Routes environment-specific changes to the matching `shared`, `prod`, or `dev` Terraform state
+- Deploys shared infrastructure before dependent prod/dev infrastructure when common configuration changes
+- Keeps pull-request plans on the isolated dev environment; applies run only from `main` or manual dispatch
+- Avoids infrastructure applies for workflow, documentation, and test-only changes
+- Manages AWS infrastructure changes using a reusable per-environment workflow
 - Runs independently of application code changes
 - Includes Terraform planning and apply steps
 - Manages AWS resources like VPC, ECS clusters, RDS, and load balancers

--- a/.github/workflows/deploy_infra.yml
+++ b/.github/workflows/deploy_infra.yml
@@ -33,6 +33,10 @@ on:
           - prod
           - dev
 
+concurrency:
+  group: terraform-infrastructure-${{ github.ref }}
+  queue: max
+
 env:
   TF_LOG: error
 

--- a/.github/workflows/deploy_infra.yml
+++ b/.github/workflows/deploy_infra.yml
@@ -11,6 +11,7 @@ on:
       - "terraform/**"
       - ".github/workflows/deploy_infra.yml"
       - ".github/workflows/deploy_terraform_environment.yml"
+      - ".github/scripts/list_terraform_changed_paths.sh"
       - ".github/scripts/select_terraform_environments.sh"
   pull_request:
     branches: [main]
@@ -18,6 +19,7 @@ on:
       - "terraform/**"
       - ".github/workflows/deploy_infra.yml"
       - ".github/workflows/deploy_terraform_environment.yml"
+      - ".github/scripts/list_terraform_changed_paths.sh"
       - ".github/scripts/select_terraform_environments.sh"
   workflow_dispatch:
     inputs:
@@ -56,7 +58,12 @@ jobs:
         run: |
           changed_paths=()
           if [[ "${EVENT_NAME}" == "push" ]]; then
-            mapfile -t changed_paths < <(git diff --name-only "${BEFORE_SHA}" "${AFTER_SHA}")
+            changed_paths_file="${RUNNER_TEMP}/terraform_changed_paths.txt"
+            if ! .github/scripts/list_terraform_changed_paths.sh \
+              "${BEFORE_SHA}" "${AFTER_SHA}" >"${changed_paths_file}"; then
+              exit 1
+            fi
+            mapfile -t changed_paths <"${changed_paths_file}"
           fi
 
           environments="$(.github/scripts/select_terraform_environments.sh \

--- a/.github/workflows/deploy_infra.yml
+++ b/.github/workflows/deploy_infra.yml
@@ -10,11 +10,15 @@ on:
     paths:
       - "terraform/**"
       - ".github/workflows/deploy_infra.yml"
+      - ".github/workflows/deploy_terraform_environment.yml"
+      - ".github/scripts/select_terraform_environments.sh"
   pull_request:
     branches: [main]
     paths:
       - "terraform/**"
       - ".github/workflows/deploy_infra.yml"
+      - ".github/workflows/deploy_terraform_environment.yml"
+      - ".github/scripts/select_terraform_environments.sh"
   workflow_dispatch:
     inputs:
       environment:
@@ -31,24 +35,36 @@ env:
   TF_LOG: error
 
 jobs:
-  # Determine which environment to deploy
-  determine-environment:
+  determine_environments:
+    name: Determine Terraform environments
     runs-on: ubuntu-latest
     outputs:
-      environment: ${{ steps.env.outputs.environment }}
-      tf_directory: ${{ steps.env.outputs.tf_directory }}
+      environments: ${{ steps.selection.outputs.environments }}
     steps:
-      - id: env
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Select environments
+        id: selection
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          REQUESTED_ENVIRONMENT: ${{ github.event.inputs.environment || '' }}
+          BEFORE_SHA: ${{ github.event.before || '' }}
+          AFTER_SHA: ${{ github.sha }}
         run: |
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            ENV="${{ github.event.inputs.environment }}"
-          elif [ "${{ github.event_name }}" = "pull_request" ]; then
-            ENV="dev"
-          else
-            ENV="prod"
+          changed_paths=()
+          if [[ "${EVENT_NAME}" == "push" ]]; then
+            mapfile -t changed_paths < <(git diff --name-only "${BEFORE_SHA}" "${AFTER_SHA}")
           fi
-          echo "environment=$ENV" >> $GITHUB_OUTPUT
-          echo "tf_directory=terraform/environments/$ENV" >> $GITHUB_OUTPUT
+
+          environments="$(.github/scripts/select_terraform_environments.sh \
+            "${EVENT_NAME}" \
+            "${REQUESTED_ENVIRONMENT}" \
+            "${changed_paths[@]}")"
+          echo "environments=${environments}" >>"${GITHUB_OUTPUT}"
+          echo "stage=environment-selection correlation=github-run-${GITHUB_RUN_ID} outcome=success environments=${environments}"
 
   # Wait for terraform tests to complete successfully before deploying
   wait_for_tests:
@@ -63,15 +79,17 @@ jobs:
 
       - name: Check if terraform tests should be running
         id: check_terraform_changes
+        env:
+          EVENT_NAME: ${{ github.event_name }}
         run: |
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            echo "terraform_changed=false" >> $GITHUB_OUTPUT
+          if [[ "${EVENT_NAME}" == "workflow_dispatch" ]]; then
+            echo "terraform_changed=false" >>"${GITHUB_OUTPUT}"
             echo "Manual trigger - skipping test wait"
           elif git diff --name-only HEAD~1 HEAD | grep -E '^terraform/'; then
-            echo "terraform_changed=true" >> $GITHUB_OUTPUT
+            echo "terraform_changed=true" >>"${GITHUB_OUTPUT}"
             echo "Terraform files changed - will wait for tests"
           else
-            echo "terraform_changed=false" >> $GITHUB_OUTPUT
+            echo "terraform_changed=false" >>"${GITHUB_OUTPUT}"
             echo "No terraform changes - skipping test wait"
           fi
 
@@ -92,121 +110,52 @@ jobs:
           echo "Terraform tests did not complete successfully: ${{ steps.wait_for_tests.outputs.conclusion }}"
           exit 1
 
-  terraform_deploy:
-    name: Terraform Plan & Apply (${{ needs.determine-environment.outputs.environment }})
-    runs-on: ubuntu-latest
-    environment: ${{ needs.determine-environment.outputs.environment }}
-    needs: [determine-environment, wait_for_tests]
-    if: always() && needs.determine-environment.result == 'success' && (needs.wait_for_tests.result == 'success' || needs.wait_for_tests.result == 'skipped')
+  deploy_shared:
+    name: Deploy shared Terraform
+    needs: [determine_environments, wait_for_tests]
+    if: >-
+      always() &&
+      needs.determine_environments.result == 'success' &&
+      (needs.wait_for_tests.result == 'success' || needs.wait_for_tests.result == 'skipped') &&
+      contains(fromJSON(needs.determine_environments.outputs.environments), 'shared')
+    uses: ./.github/workflows/deploy_terraform_environment.yml
+    with:
+      environment: shared
+    secrets: inherit
+    permissions:
+      contents: read
+      id-token: write
 
-    env:
-      TF_DIRECTORY: ${{ needs.determine-environment.outputs.tf_directory }}
-      # Secrets (from GitHub environment)
-      TF_VAR_db_password: ${{ secrets.DB_PASSWORD }}
-      TF_VAR_db_username: ${{ secrets.DB_USERNAME }}
-      TF_VAR_app_db_username: ${{ secrets.APP_DB_USERNAME }}
-      TF_VAR_app_db_password: ${{ secrets.APP_DB_PASSWORD }}
-      TF_VAR_bastion_public_key: ${{ secrets.TF_VAR_BASTION_PUBLIC_KEY }}
-      TF_VAR_site_password: ${{ secrets.SITE_PASSWORD }}
-      TF_VAR_shared_peering_role_arn: ${{ secrets.SHARED_PEERING_ROLE_ARN }}
-      # Variables (from GitHub environment)
-      TF_VAR_prefix: ${{ vars.TF_VAR_PREFIX }}
-      TF_VAR_shared_account_id: ${{ vars.SHARED_ACCOUNT_ID }}
-      TF_VAR_github_repo: ${{ vars.REPO_FULL_NAME }}
-      TF_VAR_domain_name: ${{ vars.TF_VAR_DOMAIN_NAME }}
-      TF_VAR_api_gateway_id: ${{ vars.TF_VAR_API_GATEWAY_ID }}
-      TF_VAR_alert_email: ${{ vars.TF_VAR_ALERT_EMAIL }}
-      TF_VAR_ses_from_email: ${{ vars.SES_FROM_EMAIL }}
-      TF_VAR_ses_notification_email: ${{ vars.SES_NOTIFICATION_EMAIL }}
-      # Shared-only variables (unused by dev/prod but harmless as empty env vars)
-      TF_VAR_bastion_key_name: ${{ vars.BASTION_KEY_NAME }}
-      TF_VAR_allowed_bastion_cidrs: ${{ vars.ALLOWED_BASTION_CIDRS }}
-      TF_VAR_allowed_lambda_cidrs: ${{ vars.ALLOWED_LAMBDA_CIDRS }}
+  deploy_prod:
+    name: Deploy prod Terraform
+    needs: [determine_environments, wait_for_tests, deploy_shared]
+    if: >-
+      always() &&
+      needs.determine_environments.result == 'success' &&
+      (needs.wait_for_tests.result == 'success' || needs.wait_for_tests.result == 'skipped') &&
+      (needs.deploy_shared.result == 'success' || needs.deploy_shared.result == 'skipped') &&
+      contains(fromJSON(needs.determine_environments.outputs.environments), 'prod')
+    uses: ./.github/workflows/deploy_terraform_environment.yml
+    with:
+      environment: prod
+    secrets: inherit
+    permissions:
+      contents: read
+      id-token: write
 
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Validate required variables
-        run: |
-          if [ -z "${{ vars.AWS_ACCOUNT_ID }}" ]; then
-            echo "::error::AWS_ACCOUNT_ID variable is not set in the '${{ needs.determine-environment.outputs.environment }}' GitHub environment"
-            exit 1
-          fi
-          if [ -z "${{ vars.TF_VAR_PREFIX }}" ]; then
-            echo "::error::TF_VAR_PREFIX variable is not set in the '${{ needs.determine-environment.outputs.environment }}' GitHub environment"
-            exit 1
-          fi
-
-      - name: Configure AWS credentials via OIDC
-        uses: aws-actions/configure-aws-credentials@v4
-        with:
-          role-to-assume: arn:aws:iam::${{ vars.AWS_ACCOUNT_ID }}:role/github-actions-${{ needs.determine-environment.outputs.environment }}
-          aws-region: us-east-1
-
-      - name: Setup Terraform
-        uses: hashicorp/setup-terraform@v2
-        with:
-          terraform_version: 1.12.1
-
-      - name: Setup Remote State and Backend
-        run: |
-          cd "$TF_DIRECTORY"
-          # Make the setup script executable and run it
-          chmod +x ../../scripts/setup_remote_state.sh
-          ../../scripts/setup_remote_state.sh "${{ needs.determine-environment.outputs.environment }}"
-
-      - name: Terraform Init
-        run: |
-          cd "$TF_DIRECTORY"
-          timeout 5m terraform init -backend-config=backend.hcl -input=false
-
-      - name: Terraform Validate
-        run: |
-          cd "$TF_DIRECTORY"
-          terraform validate
-
-      - name: Terraform Plan
-        id: plan
-        run: |
-          cd "$TF_DIRECTORY"
-
-          echo "Running terraform plan..."
-          set +e
-          terraform plan -no-color -input=false -out=tfplan > plan_output.txt 2>&1
-          PLAN_EXIT_CODE=$?
-          set -e
-
-          echo "Plan completed with exit code: $PLAN_EXIT_CODE"
-
-          echo "::group::Terraform Plan Output"
-          cat plan_output.txt
-          echo "::endgroup::"
-
-          if [ $PLAN_EXIT_CODE -ne 0 ]; then
-            echo "::error::Terraform plan failed with exit code $PLAN_EXIT_CODE"
-            exit 1
-          fi
-
-          if grep -q "No changes. Your infrastructure matches the configuration." plan_output.txt; then
-            echo "has_changes=false" >> $GITHUB_OUTPUT
-            echo "::notice::No infrastructure changes detected"
-          else
-            echo "has_changes=true" >> $GITHUB_OUTPUT
-            echo "::notice::Infrastructure changes detected"
-          fi
-
-      - name: Terraform Apply
-        if: github.ref == 'refs/heads/main' && steps.plan.outputs.has_changes == 'true'
-        run: |
-          cd "$TF_DIRECTORY"
-
-          echo "Applying infrastructure changes..."
-
-          if terraform apply tfplan; then
-            echo "Terraform apply completed successfully"
-            echo "::notice::Infrastructure changes have been successfully applied"
-          else
-            echo "Terraform apply failed"
-            exit 1
-          fi
+  deploy_dev:
+    name: Deploy dev Terraform
+    needs: [determine_environments, wait_for_tests, deploy_shared]
+    if: >-
+      always() &&
+      needs.determine_environments.result == 'success' &&
+      (needs.wait_for_tests.result == 'success' || needs.wait_for_tests.result == 'skipped') &&
+      (needs.deploy_shared.result == 'success' || needs.deploy_shared.result == 'skipped') &&
+      contains(fromJSON(needs.determine_environments.outputs.environments), 'dev')
+    uses: ./.github/workflows/deploy_terraform_environment.yml
+    with:
+      environment: dev
+    secrets: inherit
+    permissions:
+      contents: read
+      id-token: write

--- a/.github/workflows/deploy_terraform_environment.yml
+++ b/.github/workflows/deploy_terraform_environment.yml
@@ -1,0 +1,109 @@
+name: Deploy Terraform Environment
+
+on:
+  workflow_call:
+    inputs:
+      environment:
+        description: Terraform environment to plan or apply
+        required: true
+        type: string
+
+permissions:
+  contents: read
+  id-token: write
+
+env:
+  TF_LOG: error
+
+jobs:
+  terraform-deploy:
+    name: Terraform Plan & Apply (${{ inputs.environment }})
+    runs-on: ubuntu-latest
+    environment: ${{ inputs.environment }}
+
+    env:
+      TF_DIRECTORY: terraform/environments/${{ inputs.environment }}
+      TF_VAR_db_password: ${{ secrets.DB_PASSWORD }}
+      TF_VAR_db_username: ${{ secrets.DB_USERNAME }}
+      TF_VAR_app_db_username: ${{ secrets.APP_DB_USERNAME }}
+      TF_VAR_app_db_password: ${{ secrets.APP_DB_PASSWORD }}
+      TF_VAR_bastion_public_key: ${{ secrets.TF_VAR_BASTION_PUBLIC_KEY }}
+      TF_VAR_site_password: ${{ secrets.SITE_PASSWORD }}
+      TF_VAR_shared_peering_role_arn: ${{ secrets.SHARED_PEERING_ROLE_ARN }}
+      TF_VAR_prefix: ${{ vars.TF_VAR_PREFIX }}
+      TF_VAR_shared_account_id: ${{ vars.SHARED_ACCOUNT_ID }}
+      TF_VAR_github_repo: ${{ vars.REPO_FULL_NAME }}
+      TF_VAR_domain_name: ${{ vars.TF_VAR_DOMAIN_NAME }}
+      TF_VAR_api_gateway_id: ${{ vars.TF_VAR_API_GATEWAY_ID }}
+      TF_VAR_alert_email: ${{ vars.TF_VAR_ALERT_EMAIL }}
+      TF_VAR_ses_from_email: ${{ vars.SES_FROM_EMAIL }}
+      TF_VAR_ses_notification_email: ${{ vars.SES_NOTIFICATION_EMAIL }}
+      TF_VAR_bastion_key_name: ${{ vars.BASTION_KEY_NAME }}
+      TF_VAR_allowed_bastion_cidrs: ${{ vars.ALLOWED_BASTION_CIDRS }}
+      TF_VAR_allowed_lambda_cidrs: ${{ vars.ALLOWED_LAMBDA_CIDRS }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Validate required variables
+        env:
+          AWS_ACCOUNT_ID: ${{ vars.AWS_ACCOUNT_ID }}
+          TF_PREFIX: ${{ vars.TF_VAR_PREFIX }}
+        run: |
+          if [[ -z "${AWS_ACCOUNT_ID}" ]]; then
+            echo "::error::AWS_ACCOUNT_ID is not set in the '${{ inputs.environment }}' GitHub environment"
+            exit 1
+          fi
+          if [[ -z "${TF_PREFIX}" ]]; then
+            echo "::error::TF_VAR_PREFIX is not set in the '${{ inputs.environment }}' GitHub environment"
+            exit 1
+          fi
+
+      - name: Configure AWS credentials via OIDC
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: arn:aws:iam::${{ vars.AWS_ACCOUNT_ID }}:role/github-actions-${{ inputs.environment }}
+          aws-region: us-east-1
+
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: 1.12.1
+
+      - name: Setup remote state and backend
+        working-directory: ${{ env.TF_DIRECTORY }}
+        run: |
+          ../../scripts/setup_remote_state.sh "${{ inputs.environment }}"
+
+      - name: Terraform init
+        working-directory: ${{ env.TF_DIRECTORY }}
+        run: timeout 5m terraform init -backend-config=backend.hcl -input=false
+
+      - name: Terraform validate
+        working-directory: ${{ env.TF_DIRECTORY }}
+        run: terraform validate
+
+      - name: Terraform plan
+        id: plan
+        working-directory: ${{ env.TF_DIRECTORY }}
+        run: |
+          if ! terraform plan -no-color -input=false -out=tfplan >plan_output.txt 2>&1; then
+            cat plan_output.txt
+            echo "::error::Terraform plan failed"
+            exit 1
+          fi
+
+          cat plan_output.txt
+          if grep -q "No changes. Your infrastructure matches the configuration." plan_output.txt; then
+            echo "has_changes=false" >>"${GITHUB_OUTPUT}"
+            echo "::notice::No infrastructure changes detected"
+          else
+            echo "has_changes=true" >>"${GITHUB_OUTPUT}"
+            echo "::notice::Infrastructure changes detected"
+          fi
+
+      - name: Terraform apply
+        if: github.ref == 'refs/heads/main' && steps.plan.outputs.has_changes == 'true'
+        working-directory: ${{ env.TF_DIRECTORY }}
+        run: terraform apply tfplan

--- a/.github/workflows/lint_shellcheck.yml
+++ b/.github/workflows/lint_shellcheck.yml
@@ -29,3 +29,6 @@ jobs:
       - name: Run ShellCheck
         run: |
           find . -type f -name "*.sh" -not -path "*/node_modules/*" -not -path "*/.git/*" -not -path "*/.terraform/*" -exec shellcheck -x {} \;
+
+      - name: Test Terraform deployment environment selection
+        run: .github/scripts/test_select_terraform_environments.sh


### PR DESCRIPTION
## Summary

- select Terraform deployment environments from the files changed on `main`
- route environment-specific changes to `shared`, `prod`, or `dev`
- deploy `shared` before dependent prod/dev environments for common Terraform changes
- centralize plan/apply behavior in a reusable per-environment workflow
- keep pull-request plans isolated to dev and avoid applies for workflow, documentation, and test-only changes
- add deterministic selection tests to ShellCheck CI

## Why

The previous workflow routed every non-manual main-branch Terraform change to `prod`. As a result, the merged Google Workspace MX record in the shared Route 53 state was never applied, while an unrelated prod backend checksum error caused the deployment run to fail.

## Impact

Future shared Terraform changes will deploy the shared state instead of prod. Common Terraform changes run shared first, then prod and dev. A failure in prod cannot prevent an already-selected shared deployment from completing.

This PR intentionally does not bypass or mutate the existing prod S3/DynamoDB state checksum mismatch. That remote state needs a separate operational consistency audit.

After this PR is merged, manually dispatch **Terraform Infrastructure CI/CD** with `environment=shared` once to apply the already-merged MX record; workflow-only changes correctly do not trigger infrastructure applies.

## Validation

- environment-selection tests, including invalid inputs and multi-environment ordering
- repository-wide ShellCheck
- Actionlint for all changed workflows
- Prettier for changed YAML and Markdown
- `terraform fmt -check -recursive terraform`
- backend-disabled `terraform validate` for shared, prod, and dev