### PR TITLE
Fix deployment verification and CDN image loading

### DIFF
--- a/.github/scripts/test_deployment_workflows.sh
+++ b/.github/scripts/test_deployment_workflows.sh
@@ -57,6 +57,7 @@ require_text "${lambda_workflow}" "\${DEPLOYMENT_API_URL%/}/api/health/"
 
 require_text "${frontend_workflow}" 'group: deploy-frontend-'
 require_text "${frontend_workflow}" "cancel-in-progress: false"
+require_text "${frontend_workflow}" "CLOUDFRONT_DOMAIN: \${{ vars.CLOUDFRONT_DOMAIN }}"
 
 require_text "${management_workflow}" "role-to-assume:"
 reject_text "${management_workflow}" "aws-access-key-id:"

--- a/.github/scripts/test_deployment_workflows.sh
+++ b/.github/scripts/test_deployment_workflows.sh
@@ -57,6 +57,7 @@ require_text "${lambda_workflow}" "\${DEPLOYMENT_API_URL%/}/api/health/"
 
 require_text "${frontend_workflow}" 'group: deploy-frontend-'
 require_text "${frontend_workflow}" "cancel-in-progress: false"
+require_text "${frontend_workflow}" "SITE_URL=\"\${{ vars.DEVELOPMENT_SITE_URL || vars.PRODUCTION_SITE_URL }}\""
 require_text "${frontend_workflow}" "CLOUDFRONT_DOMAIN: \${{ vars.CLOUDFRONT_DOMAIN }}"
 
 require_text "${management_workflow}" "role-to-assume:"

--- a/.github/scripts/test_deployment_workflows.sh
+++ b/.github/scripts/test_deployment_workflows.sh
@@ -28,6 +28,20 @@ require_text() {
   grep -Fq -- "${expected}" "${path}" || fail "expected ${path} to contain: ${expected}"
 }
 
+require_step_text() {
+  local path="$1"
+  local step_name="$2"
+  local expected="$3"
+  local step_text
+
+  step_text="$(awk -v heading="      - name: ${step_name}" '
+    $0 == heading { in_step = 1 }
+    in_step && $0 != heading && /^      - name:/ { exit }
+    in_step { print }
+  ' "${path}")"
+  grep -Fq -- "${expected}" <<<"${step_text}" || fail "expected ${step_name} step in ${path} to contain: ${expected}"
+}
+
 reject_text() {
   local path="$1"
   local rejected="$2"
@@ -58,7 +72,7 @@ require_text "${lambda_workflow}" "\${DEPLOYMENT_API_URL%/}/api/health/"
 require_text "${frontend_workflow}" 'group: deploy-frontend-'
 require_text "${frontend_workflow}" "cancel-in-progress: false"
 require_text "${frontend_workflow}" "SITE_URL=\"\${{ vars.DEVELOPMENT_SITE_URL || vars.PRODUCTION_SITE_URL }}\""
-require_text "${frontend_workflow}" "CLOUDFRONT_DOMAIN: \${{ vars.CLOUDFRONT_DOMAIN }}"
+require_step_text "${frontend_workflow}" "Build Project Artifacts" "CLOUDFRONT_DOMAIN: \${{ vars.CLOUDFRONT_DOMAIN }}"
 
 require_text "${management_workflow}" "role-to-assume:"
 reject_text "${management_workflow}" "aws-access-key-id:"

--- a/.github/scripts/test_deployment_workflows.sh
+++ b/.github/scripts/test_deployment_workflows.sh
@@ -53,6 +53,7 @@ require_text "${lambda_workflow}" "migrate --noinput"
 require_text "${lambda_workflow}" "collectstatic --noinput"
 require_text "${lambda_workflow}" "--connect-timeout 5"
 require_text "${lambda_workflow}" "--max-time 15"
+require_text "${lambda_workflow}" "\${DEPLOYMENT_API_URL%/}/api/health/"
 
 require_text "${frontend_workflow}" 'group: deploy-frontend-'
 require_text "${frontend_workflow}" "cancel-in-progress: false"

--- a/.github/workflows/deploy_frontend.yml
+++ b/.github/workflows/deploy_frontend.yml
@@ -79,7 +79,7 @@ jobs:
             SITE_URL="${{ vars.PRODUCTION_SITE_URL }}"
           else
             API_URL="${{ vars.DEVELOPMENT_API_URL }}"
-            SITE_URL="${{ vars.DEVELOPMENT_SITE_URL }}"
+            SITE_URL="${{ vars.DEVELOPMENT_SITE_URL || vars.PRODUCTION_SITE_URL }}"
           fi
 
           if [[ -z "${API_URL}" || -z "${SITE_URL}" || -z "${CLOUDFRONT_DOMAIN}" ]]; then

--- a/.github/workflows/deploy_frontend.yml
+++ b/.github/workflows/deploy_frontend.yml
@@ -68,6 +68,8 @@ jobs:
 
       - name: Set API URL
         id: api
+        env:
+          CLOUDFRONT_DOMAIN: ${{ vars.CLOUDFRONT_DOMAIN }}
         run: |
           ENV="${{ steps.env.outputs.environment }}"
 
@@ -78,6 +80,11 @@ jobs:
           else
             API_URL="${{ vars.DEVELOPMENT_API_URL }}"
             SITE_URL="${{ vars.DEVELOPMENT_SITE_URL }}"
+          fi
+
+          if [[ -z "${API_URL}" || -z "${SITE_URL}" || -z "${CLOUDFRONT_DOMAIN}" ]]; then
+            echo "::error::API URL, site URL, and CLOUDFRONT_DOMAIN are required for frontend builds"
+            exit 1
           fi
 
           {
@@ -119,6 +126,7 @@ jobs:
           NEXT_PUBLIC_ENVIRONMENT: ${{ steps.env.outputs.environment }}
           NEXT_PUBLIC_SITE_URL: ${{ steps.api.outputs.site_url }}
           NEXT_PUBLIC_GOOGLE_ANALYTICS_ID: ${{ vars.GOOGLE_ANALYTICS_ID }}
+          CLOUDFRONT_DOMAIN: ${{ vars.CLOUDFRONT_DOMAIN }}
           AWS_STORAGE_BUCKET_NAME: ${{ vars.AWS_STORAGE_BUCKET_NAME }}
           VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
 

--- a/.github/workflows/deploy_lambda.yml
+++ b/.github/workflows/deploy_lambda.yml
@@ -307,7 +307,7 @@ jobs:
             --retry-delay 5 \
             --connect-timeout 5 \
             --max-time 15 \
-            "${DEPLOYMENT_API_URL%/}/health/"
+            "${DEPLOYMENT_API_URL%/}/api/health/"
 
       - name: Report deployment
         env:

--- a/docs/VERCEL_DEPLOYMENT.md
+++ b/docs/VERCEL_DEPLOYMENT.md
@@ -38,12 +38,14 @@ Add these as **repository secrets** in GitHub:
 
 ### 4. Set GitHub Variables
 
-Add these as **repository variables** (or environment-specific):
+Add these as **repository variables**. The frontend deployment job does not
+select a GitHub environment, so environment-scoped variables are not available
+to it.
 
 #### Development
 
 - `DEVELOPMENT_API_URL`: `https://api-dev.yourdomain.com` or Lambda API Gateway URL
-- `DEVELOPMENT_SITE_URL`: `https://dev.yourdomain.com`
+- `DEVELOPMENT_SITE_URL`: `https://dev.yourdomain.com` (optional; falls back to `PRODUCTION_SITE_URL`)
 
 #### Staging
 
@@ -55,6 +57,11 @@ Add these as **repository variables** (or environment-specific):
 - `PRODUCTION_API_URL`: `https://api.yourdomain.com` or Lambda API Gateway URL
 - `PRODUCTION_SITE_URL`: `https://yourdomain.com`
 - `PRODUCTION_DOMAIN`: `yourdomain.com` (for aliasing)
+
+#### Shared build configuration
+
+- `CLOUDFRONT_DOMAIN`: `d123456789.cloudfront.net` (required for image optimization)
+- `AWS_STORAGE_BUCKET_NAME`: `your-assets-bucket` (required when images are served directly from S3)
 
 #### Optional
 

--- a/docs/VERCEL_DEPLOYMENT.md
+++ b/docs/VERCEL_DEPLOYMENT.md
@@ -67,25 +67,22 @@ to it.
 
 - `GOOGLE_ANALYTICS_ID`: Your GA tracking ID
 
-## Environment Variables in Vercel
+## Build-Time Environment
 
-### Build-Time Variables (set by CI workflow)
+The GitHub Actions workflow passes the selected repository variables to
+`vercel build` as:
 
-The GitHub Actions deployment workflow sets these `NEXT_PUBLIC_*` variables at build time. They are baked into the JavaScript bundle and cannot be changed without rebuilding:
-
-- `NEXT_PUBLIC_API_URL`: Backend API URL (Lambda/API Gateway)
-- `NEXT_PUBLIC_ENVIRONMENT`: Current environment (dev/staging/production)
+- `API_URL` and `NEXT_PUBLIC_API_URL`: Backend API URL (Lambda/API Gateway)
+- `NEXT_PUBLIC_ENVIRONMENT`: Current deployment environment
 - `NEXT_PUBLIC_SITE_URL`: Frontend URL
 - `NEXT_PUBLIC_GOOGLE_ANALYTICS_ID`: Google Analytics ID
+- `CLOUDFRONT_DOMAIN`: CloudFront hostname allowed by Next.js image optimization
+- `AWS_STORAGE_BUCKET_NAME`: S3 hostname allowed by Next.js image optimization
 
-### Runtime Variables (set in Vercel dashboard)
-
-These variables must be set directly in the Vercel project settings (Settings > Environment Variables) because they are read at runtime by the Next.js server, not baked in at build time:
-
-- `API_URL`: The API Gateway invoke URL including the stage path (e.g., `https://abc123.execute-api.us-east-1.amazonaws.com/prod`). Used by `next.config.js` server-side rewrites to proxy `/api/*` requests to the Lambda backend.
-- `AWS_STORAGE_BUCKET_NAME`: The S3 bucket name for production assets (e.g., `coalition-static-assets-a4853294`). Used by `next.config.js` `remotePatterns` to allow Next.js image optimization for S3-hosted media files.
-
-**Important:** These runtime variables are not set by the CI workflow — they must be configured manually in the Vercel dashboard for each environment (Production, Preview, Development).
+Next.js evaluates these values while creating the prebuilt artifact. The deploy
+step cannot change them. For a manual `vercel build` outside GitHub Actions,
+mirror the same values in the corresponding Vercel project environment and keep
+them synchronized with the repository variables.
 
 ## Deployment Workflow
 
@@ -153,7 +150,10 @@ async rewrites() {
 },
 ```
 
-Set `API_URL` in the Vercel dashboard (see [Runtime Variables](#runtime-variables-set-in-vercel-dashboard) above) to your API Gateway invoke URL including the stage path, e.g., `https://abc123.execute-api.us-east-1.amazonaws.com/prod`.
+Set `PRODUCTION_API_URL` and `DEVELOPMENT_API_URL` as described in
+[Set GitHub Variables](#4-set-github-variables). The workflow passes the selected
+value to `next.config.js` as `API_URL` during the build. For manual builds, mirror
+that value in the corresponding Vercel project environment.
 
 > **Note:** Do **not** add API rewrites to `vercel.json`. Vercel edge rewrites do not properly set the `Host` header for API Gateway URLs, which causes CloudFront to return `403 Forbidden`. The `next.config.js` server-side rewrites handle this correctly.
 
@@ -165,7 +165,7 @@ If you are setting up a fresh deployment or migrating to a new environment, ensu
 
 1. The S3 assets bucket exists and is accessible
 2. Any required media files are uploaded to the `media/` prefix in the bucket
-3. `AWS_STORAGE_BUCKET_NAME` is set in both the Lambda environment and the Vercel dashboard (for image optimization)
+3. `AWS_STORAGE_BUCKET_NAME` is set in the Lambda GitHub environment and as a repository variable for the frontend build
 
 ## Preview Deployments
 

--- a/docs/VERCEL_DEPLOYMENT.md
+++ b/docs/VERCEL_DEPLOYMENT.md
@@ -82,7 +82,9 @@ The GitHub Actions workflow passes the selected repository variables to
 Next.js evaluates these values while creating the prebuilt artifact. The deploy
 step cannot change them. For a manual `vercel build` outside GitHub Actions,
 mirror the same values in the corresponding Vercel project environment and keep
-them synchronized with the repository variables.
+them synchronized with the repository variables. Immediately before building,
+refresh Vercel's local cache with `vercel pull --yes --environment=preview` or
+`vercel pull --yes --environment=production`, as appropriate.
 
 ## Deployment Workflow
 

--- a/docs/deployment/workflows.md
+++ b/docs/deployment/workflows.md
@@ -56,6 +56,12 @@ Deploys the Next.js frontend to Vercel.
 - `VERCEL_PROJECT_ID` (secret)
 - `PRODUCTION_API_URL` (variable)
 - `DEVELOPMENT_API_URL` (variable)
+- `PRODUCTION_SITE_URL` (variable; fallback for non-production builds)
+- `CLOUDFRONT_DOMAIN` (variable)
+
+These must be repository-scoped because the frontend job does not select a
+GitHub environment. `DEVELOPMENT_SITE_URL` is optional; when absent, preview and
+development builds use `PRODUCTION_SITE_URL` for site metadata.
 
 **Process:**
 


### PR DESCRIPTION
## Summary

- verify Lambda deployments against the existing Django health endpoint at `/api/health/`
- pass the configured CloudFront hostname into Vercel's frontend build
- fail frontend builds when the API URL, site URL, or CDN hostname is missing
- add deployment-workflow regression assertions for both contracts

## Root causes

The Lambda deployment completed successfully, but its final check requested the nonexistent `/health/` route instead of `/api/health/`.

The latest Vercel build did not receive `CLOUDFRONT_DOMAIN`. Next.js therefore omitted the live CDN hostname from `images.remotePatterns`, and every optimized CDN image request returned `400 INVALID_IMAGE_OPTIMIZE_REQUEST`, even though the underlying CloudFront objects returned HTTP 200.

## Impact

Lambda deployments will report the real application/database health result, and Vercel will accept and optimize images served from the configured CloudFront distribution.

## Validation

- red/green deployment workflow regression tests
- ShellCheck
- actionlint
- Prettier
- direct CloudFront image objects return HTTP 200
- production application endpoints return HTTP 200
