### PR TITLE
Reconcile Terraform state and prevent destructive drift

### DIFF
--- a/.github/scripts/test_deployment_workflows.sh
+++ b/.github/scripts/test_deployment_workflows.sh
@@ -7,6 +7,7 @@ lambda_workflow="${repository_root}/.github/workflows/deploy_lambda.yml"
 frontend_workflow="${repository_root}/.github/workflows/deploy_frontend.yml"
 management_workflow="${repository_root}/.github/workflows/lambda_management.yml"
 terraform_workflow="${repository_root}/.github/workflows/deploy_terraform_environment.yml"
+shellcheck_workflow="${repository_root}/.github/workflows/lint_shellcheck.yml"
 
 fail() {
   echo "FAIL: $1" >&2
@@ -29,6 +30,19 @@ require_text() {
   grep -Fq -- "${expected}" "${path}" || fail "expected ${path} to contain: ${expected}"
 }
 
+require_text_occurrences() {
+  local path="$1"
+  local expected="$2"
+  local expected_count="$3"
+  local actual_count
+
+  if ! actual_count="$(grep -Fc -- "${expected}" "${path}")"; then
+    actual_count=0
+  fi
+  [[ "${actual_count}" -eq "${expected_count}" ]] ||
+    fail "expected ${path} to contain ${expected_count} occurrences of: ${expected}"
+}
+
 reject_text() {
   local path="$1"
   local rejected="$2"
@@ -41,6 +55,7 @@ require_file "${lambda_workflow}"
 require_file "${frontend_workflow}"
 require_file "${management_workflow}"
 require_file "${terraform_workflow}"
+require_file "${shellcheck_workflow}"
 require_absent_file "${repository_root}/.github/workflows/deploy_app.yml"
 require_absent_file "${repository_root}/.github/workflows/deploy_serverless.yml"
 
@@ -64,7 +79,11 @@ reject_text "${management_workflow}" "aws-access-key-id:"
 reject_text "${management_workflow}" "aws-secret-access-key:"
 require_text "${management_workflow}" "scripts/configure_zappa.py"
 
-require_text "${terraform_workflow}" 'TF_VAR_create_new_key_pair: ${{ vars.CREATE_NEW_KEY_PAIR }}'
+require_text "${terraform_workflow}" "TF_VAR_create_new_key_pair: \${{ vars.CREATE_NEW_KEY_PAIR }}"
 require_text "${terraform_workflow}" "validate_terraform_environment_variables.sh"
+require_text_occurrences \
+  "${shellcheck_workflow}" \
+  '".github/workflows/deploy_terraform_environment.yml"' \
+  2
 
 echo "Deployment workflow regression tests passed."

--- a/.github/scripts/test_deployment_workflows.sh
+++ b/.github/scripts/test_deployment_workflows.sh
@@ -6,6 +6,7 @@ repository_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 lambda_workflow="${repository_root}/.github/workflows/deploy_lambda.yml"
 frontend_workflow="${repository_root}/.github/workflows/deploy_frontend.yml"
 management_workflow="${repository_root}/.github/workflows/lambda_management.yml"
+terraform_workflow="${repository_root}/.github/workflows/deploy_terraform_environment.yml"
 
 fail() {
   echo "FAIL: $1" >&2
@@ -39,6 +40,7 @@ reject_text() {
 require_file "${lambda_workflow}"
 require_file "${frontend_workflow}"
 require_file "${management_workflow}"
+require_file "${terraform_workflow}"
 require_absent_file "${repository_root}/.github/workflows/deploy_app.yml"
 require_absent_file "${repository_root}/.github/workflows/deploy_serverless.yml"
 
@@ -61,5 +63,8 @@ require_text "${management_workflow}" "role-to-assume:"
 reject_text "${management_workflow}" "aws-access-key-id:"
 reject_text "${management_workflow}" "aws-secret-access-key:"
 require_text "${management_workflow}" "scripts/configure_zappa.py"
+
+require_text "${terraform_workflow}" 'TF_VAR_create_new_key_pair: ${{ vars.CREATE_NEW_KEY_PAIR }}'
+require_text "${terraform_workflow}" "validate_terraform_environment_variables.sh"
 
 echo "Deployment workflow regression tests passed."

--- a/.github/scripts/test_validate_terraform_environment_variables.sh
+++ b/.github/scripts/test_validate_terraform_environment_variables.sh
@@ -19,6 +19,7 @@ shared_environment=(
   TF_VAR_allowed_lambda_cidrs='["10.1.3.0/24"]'
   TF_VAR_alert_email=admin@landandbay.org
   TF_VAR_domain_name=landandbay.org
+  TF_VAR_github_repo=lhadjchikh/coalition-builder
 )
 
 assert_shared_configuration_is_accepted() {
@@ -78,6 +79,7 @@ assert_shared_configuration_is_accepted
 assert_missing_variable_is_rejected TF_VAR_db_password
 assert_missing_variable_is_rejected TF_VAR_bastion_public_key
 assert_missing_variable_is_rejected TF_VAR_create_new_key_pair
+assert_missing_variable_is_rejected TF_VAR_github_repo
 assert_empty_network_boundary_is_rejected
 assert_prod_configuration_is_accepted
 assert_unknown_environment_is_rejected

--- a/.github/scripts/test_validate_terraform_environment_variables.sh
+++ b/.github/scripts/test_validate_terraform_environment_variables.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+SCRIPT_DIRECTORY="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+readonly SCRIPT_DIRECTORY
+readonly VALIDATOR="${SCRIPT_DIRECTORY}/validate_terraform_environment_variables.sh"
+
+shared_environment=(
+  AWS_ACCOUNT_ID=200363996622
+  TF_VAR_prefix=landandbay
+  TF_VAR_db_username=lab_admin
+  TF_VAR_db_password=secret
+  TF_VAR_app_db_username=coalition_app
+  TF_VAR_bastion_public_key=ssh-rsa-placeholder
+  TF_VAR_bastion_key_name=landandbay-bastion
+  TF_VAR_create_new_key_pair=true
+  TF_VAR_allowed_bastion_cidrs='["0.0.0.0/0"]'
+  TF_VAR_allowed_lambda_cidrs='["10.1.3.0/24"]'
+  TF_VAR_alert_email=admin@landandbay.org
+  TF_VAR_domain_name=landandbay.org
+)
+
+assert_shared_configuration_is_accepted() {
+  env -i PATH="${PATH}" GITHUB_RUN_ID=test \
+    "${shared_environment[@]}" \
+    "${VALIDATOR}" shared >/dev/null
+}
+
+assert_missing_variable_is_rejected() {
+  local rejected_variable="$1"
+  local variables=()
+  local assignment
+
+  for assignment in "${shared_environment[@]}"; do
+    if [[ "${assignment}" != "${rejected_variable}="* ]]; then
+      variables+=("${assignment}")
+    fi
+  done
+
+  if env -i PATH="${PATH}" GITHUB_RUN_ID=test \
+    "${variables[@]}" \
+    "${VALIDATOR}" shared >/dev/null 2>&1; then
+    printf 'Expected shared validation to reject missing %s\n' \
+      "${rejected_variable}" >&2
+    return 1
+  fi
+}
+
+assert_empty_network_boundary_is_rejected() {
+  if env -i PATH="${PATH}" GITHUB_RUN_ID=test \
+    "${shared_environment[@]}" \
+    TF_VAR_allowed_lambda_cidrs='[]' \
+    "${VALIDATOR}" shared >/dev/null 2>&1; then
+    printf 'Expected shared validation to reject empty Lambda CIDRs\n' >&2
+    return 1
+  fi
+}
+
+assert_prod_configuration_is_accepted() {
+  env -i PATH="${PATH}" GITHUB_RUN_ID=test \
+    AWS_ACCOUNT_ID=956322717133 \
+    TF_VAR_prefix=landandbay \
+    "${VALIDATOR}" prod >/dev/null
+}
+
+assert_unknown_environment_is_rejected() {
+  if env -i PATH="${PATH}" GITHUB_RUN_ID=test \
+    AWS_ACCOUNT_ID=956322717133 \
+    TF_VAR_prefix=landandbay \
+    "${VALIDATOR}" unknown >/dev/null 2>&1; then
+    printf 'Expected validation to reject an unknown environment\n' >&2
+    return 1
+  fi
+}
+
+assert_shared_configuration_is_accepted
+assert_missing_variable_is_rejected TF_VAR_db_password
+assert_missing_variable_is_rejected TF_VAR_bastion_public_key
+assert_missing_variable_is_rejected TF_VAR_create_new_key_pair
+assert_empty_network_boundary_is_rejected
+assert_prod_configuration_is_accepted
+assert_unknown_environment_is_rejected
+
+printf 'Terraform deployment variable validation tests passed.\n'

--- a/.github/scripts/test_validate_terraform_environment_variables.sh
+++ b/.github/scripts/test_validate_terraform_environment_variables.sh
@@ -57,14 +57,37 @@ assert_missing_variable_is_rejected() {
   fi
 }
 
+assert_all_shared_variables_are_required() {
+  local assignment
+
+  for assignment in "${shared_environment[@]}"; do
+    assert_missing_variable_is_rejected "${assignment%%=*}"
+  done
+}
+
 assert_empty_network_boundary_is_rejected() {
+  local network_variable="$1"
+
   if env -i PATH="${PATH}" GITHUB_RUN_ID=test \
     "${shared_environment[@]}" \
-    TF_VAR_allowed_lambda_cidrs='[]' \
+    "${network_variable}=[]" \
     "${VALIDATOR}" shared >/dev/null 2>&1; then
-    printf 'Expected shared validation to reject empty Lambda CIDRs\n' >&2
+    printf 'Expected shared validation to reject empty %s\n' \
+      "${network_variable}" >&2
     return 1
   fi
+}
+
+assert_empty_network_boundaries_are_rejected() {
+  local assignment
+  local variable_name
+
+  for assignment in "${shared_environment[@]}"; do
+    variable_name="${assignment%%=*}"
+    if [[ "${variable_name}" == TF_VAR_allowed_*_cidrs ]]; then
+      assert_empty_network_boundary_is_rejected "${variable_name}"
+    fi
+  done
 }
 
 assert_repository_identity_mismatch_is_rejected() {
@@ -96,11 +119,8 @@ assert_unknown_environment_is_rejected() {
 
 assert_shared_configuration_is_accepted
 assert_existing_key_configuration_is_accepted
-assert_missing_variable_is_rejected TF_VAR_db_password
-assert_missing_variable_is_rejected TF_VAR_bastion_public_key
-assert_missing_variable_is_rejected TF_VAR_create_new_key_pair
-assert_missing_variable_is_rejected TF_VAR_github_repo
-assert_empty_network_boundary_is_rejected
+assert_all_shared_variables_are_required
+assert_empty_network_boundaries_are_rejected
 assert_repository_identity_mismatch_is_rejected
 assert_prod_configuration_is_accepted
 assert_unknown_environment_is_rejected

--- a/.github/scripts/test_validate_terraform_environment_variables.sh
+++ b/.github/scripts/test_validate_terraform_environment_variables.sh
@@ -28,6 +28,14 @@ assert_shared_configuration_is_accepted() {
     "${VALIDATOR}" shared >/dev/null
 }
 
+assert_existing_key_configuration_is_accepted() {
+  env -i PATH="${PATH}" GITHUB_RUN_ID=test \
+    "${shared_environment[@]}" \
+    TF_VAR_create_new_key_pair=false \
+    TF_VAR_bastion_public_key= \
+    "${VALIDATOR}" shared >/dev/null
+}
+
 assert_missing_variable_is_rejected() {
   local rejected_variable="$1"
   local variables=()
@@ -76,6 +84,7 @@ assert_unknown_environment_is_rejected() {
 }
 
 assert_shared_configuration_is_accepted
+assert_existing_key_configuration_is_accepted
 assert_missing_variable_is_rejected TF_VAR_db_password
 assert_missing_variable_is_rejected TF_VAR_bastion_public_key
 assert_missing_variable_is_rejected TF_VAR_create_new_key_pair

--- a/.github/scripts/test_validate_terraform_environment_variables.sh
+++ b/.github/scripts/test_validate_terraform_environment_variables.sh
@@ -20,6 +20,7 @@ shared_environment=(
   TF_VAR_alert_email=admin@landandbay.org
   TF_VAR_domain_name=landandbay.org
   TF_VAR_github_repo=lhadjchikh/coalition-builder
+  GITHUB_REPOSITORY=lhadjchikh/coalition-builder
 )
 
 assert_shared_configuration_is_accepted() {
@@ -66,6 +67,16 @@ assert_empty_network_boundary_is_rejected() {
   fi
 }
 
+assert_repository_identity_mismatch_is_rejected() {
+  if env -i PATH="${PATH}" GITHUB_RUN_ID=test \
+    "${shared_environment[@]}" \
+    TF_VAR_github_repo=another-owner/another-repository \
+    "${VALIDATOR}" shared >/dev/null 2>&1; then
+    printf 'Expected shared validation to reject a repository identity mismatch\n' >&2
+    return 1
+  fi
+}
+
 assert_prod_configuration_is_accepted() {
   env -i PATH="${PATH}" GITHUB_RUN_ID=test \
     AWS_ACCOUNT_ID=956322717133 \
@@ -90,6 +101,7 @@ assert_missing_variable_is_rejected TF_VAR_bastion_public_key
 assert_missing_variable_is_rejected TF_VAR_create_new_key_pair
 assert_missing_variable_is_rejected TF_VAR_github_repo
 assert_empty_network_boundary_is_rejected
+assert_repository_identity_mismatch_is_rejected
 assert_prod_configuration_is_accepted
 assert_unknown_environment_is_rejected
 

--- a/.github/scripts/test_validate_terraform_environment_variables.sh
+++ b/.github/scripts/test_validate_terraform_environment_variables.sh
@@ -7,20 +7,20 @@ readonly SCRIPT_DIRECTORY
 readonly VALIDATOR="${SCRIPT_DIRECTORY}/validate_terraform_environment_variables.sh"
 
 shared_environment=(
-  AWS_ACCOUNT_ID=200363996622
-  TF_VAR_prefix=landandbay
-  TF_VAR_db_username=lab_admin
-  TF_VAR_db_password=secret
-  TF_VAR_app_db_username=coalition_app
+  AWS_ACCOUNT_ID=123456789012
+  TF_VAR_prefix=example-app
+  TF_VAR_db_username=platform_admin
+  TF_VAR_db_password=test-password
+  TF_VAR_app_db_username=application_user
   TF_VAR_bastion_public_key=ssh-rsa-placeholder
-  TF_VAR_bastion_key_name=landandbay-bastion
+  TF_VAR_bastion_key_name=example-bastion
   TF_VAR_create_new_key_pair=true
-  TF_VAR_allowed_bastion_cidrs='["0.0.0.0/0"]'
-  TF_VAR_allowed_lambda_cidrs='["10.1.3.0/24"]'
-  TF_VAR_alert_email=admin@landandbay.org
-  TF_VAR_domain_name=landandbay.org
-  TF_VAR_github_repo=lhadjchikh/coalition-builder
-  GITHUB_REPOSITORY=lhadjchikh/coalition-builder
+  TF_VAR_allowed_bastion_cidrs='["192.0.2.0/24"]'
+  TF_VAR_allowed_lambda_cidrs='["198.51.100.0/24"]'
+  TF_VAR_alert_email=alerts@example.invalid
+  TF_VAR_domain_name=example.invalid
+  TF_VAR_github_repo=example-org/example-repository
+  GITHUB_REPOSITORY=example-org/example-repository
 )
 
 assert_shared_configuration_is_accepted() {
@@ -102,15 +102,15 @@ assert_repository_identity_mismatch_is_rejected() {
 
 assert_prod_configuration_is_accepted() {
   env -i PATH="${PATH}" GITHUB_RUN_ID=test \
-    AWS_ACCOUNT_ID=956322717133 \
-    TF_VAR_prefix=landandbay \
+    AWS_ACCOUNT_ID=123456789012 \
+    TF_VAR_prefix=example-app \
     "${VALIDATOR}" prod >/dev/null
 }
 
 assert_unknown_environment_is_rejected() {
   if env -i PATH="${PATH}" GITHUB_RUN_ID=test \
-    AWS_ACCOUNT_ID=956322717133 \
-    TF_VAR_prefix=landandbay \
+    AWS_ACCOUNT_ID=123456789012 \
+    TF_VAR_prefix=example-app \
     "${VALIDATOR}" unknown >/dev/null 2>&1; then
     printf 'Expected validation to reject an unknown environment\n' >&2
     return 1

--- a/.github/scripts/validate_terraform_environment_variables.sh
+++ b/.github/scripts/validate_terraform_environment_variables.sh
@@ -58,6 +58,7 @@ validate_shared_environment() {
     TF_VAR_bastion_key_name
     TF_VAR_alert_email
     TF_VAR_domain_name
+    TF_VAR_github_repo
   )
 
   for required_variable in "${required_variables[@]}"; do

--- a/.github/scripts/validate_terraform_environment_variables.sh
+++ b/.github/scripts/validate_terraform_environment_variables.sh
@@ -58,11 +58,14 @@ validate_bastion_key_pair_configuration() {
 }
 
 validate_repository_identity() {
-  require_nonempty_variable TF_VAR_github_repo
-  require_nonempty_variable GITHUB_REPOSITORY
+  local configured_repository_variable=TF_VAR_github_repo
+  local actions_repository_variable=GITHUB_REPOSITORY
 
-  if [[ "${TF_VAR_github_repo}" != "${GITHUB_REPOSITORY}" ]]; then
-    fail_validation 'RepositoryIdentityMismatch' TF_VAR_github_repo \
+  require_nonempty_variable "${configured_repository_variable}"
+  require_nonempty_variable "${actions_repository_variable}"
+
+  if [[ "${!configured_repository_variable}" != "${!actions_repository_variable}" ]]; then
+    fail_validation 'RepositoryIdentityMismatch' "${configured_repository_variable}" \
       "configured repository must match the GitHub Actions repository"
   fi
 }

--- a/.github/scripts/validate_terraform_environment_variables.sh
+++ b/.github/scripts/validate_terraform_environment_variables.sh
@@ -1,0 +1,99 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+readonly CORRELATION_ID="github-run-${GITHUB_RUN_ID:-local}"
+
+fail_validation() {
+  local error_class="$1"
+  local variable_name="$2"
+  local message="$3"
+
+  printf 'stage=terraform-input-validation correlation=%s outcome=failure error_class=%s variable=%s message=%q\n' \
+    "${CORRELATION_ID}" "${error_class}" "${variable_name}" "${message}" >&2
+  exit 1
+}
+
+require_nonempty_variable() {
+  local variable_name="$1"
+
+  if [[ -z "${!variable_name:-}" ]]; then
+    fail_validation 'MissingVariable' "${variable_name}" \
+      "required deployment input is not set"
+  fi
+}
+
+require_boolean_variable() {
+  local variable_name="$1"
+
+  require_nonempty_variable "${variable_name}"
+  case "${!variable_name}" in
+    true | false) ;;
+    *)
+      fail_validation 'InvalidBoolean' "${variable_name}" \
+        "deployment input must be true or false"
+      ;;
+  esac
+}
+
+require_nonempty_string_array() {
+  local variable_name="$1"
+
+  require_nonempty_variable "${variable_name}"
+  if ! jq -e \
+    'type == "array" and length > 0 and all(.[]; type == "string" and length > 0)' \
+    <<<"${!variable_name}" >/dev/null; then
+    fail_validation 'InvalidStringArray' "${variable_name}" \
+      "deployment input must be a non-empty JSON string array"
+  fi
+}
+
+validate_shared_environment() {
+  local required_variable
+  local required_variables=(
+    TF_VAR_db_username
+    TF_VAR_db_password
+    TF_VAR_app_db_username
+    TF_VAR_bastion_public_key
+    TF_VAR_bastion_key_name
+    TF_VAR_alert_email
+    TF_VAR_domain_name
+  )
+
+  for required_variable in "${required_variables[@]}"; do
+    require_nonempty_variable "${required_variable}"
+  done
+
+  require_boolean_variable TF_VAR_create_new_key_pair
+  require_nonempty_string_array TF_VAR_allowed_bastion_cidrs
+  require_nonempty_string_array TF_VAR_allowed_lambda_cidrs
+}
+
+validate_environment() {
+  local environment="$1"
+
+  require_nonempty_variable AWS_ACCOUNT_ID
+  require_nonempty_variable TF_VAR_prefix
+
+  case "${environment}" in
+    shared) validate_shared_environment ;;
+    prod | dev) ;;
+    *)
+      fail_validation 'InvalidEnvironment' environment \
+        "deployment environment must be shared, prod, or dev"
+      ;;
+  esac
+}
+
+main() {
+  if (( $# != 1 )); then
+    fail_validation 'InvalidArguments' environment \
+      "exactly one deployment environment is required"
+  fi
+
+  validate_environment "$1"
+  printf 'stage=terraform-input-validation correlation=%s outcome=success environment=%s\n' \
+    "${CORRELATION_ID}" "$1"
+}
+
+main "$@"

--- a/.github/scripts/validate_terraform_environment_variables.sh
+++ b/.github/scripts/validate_terraform_environment_variables.sh
@@ -48,13 +48,21 @@ require_nonempty_string_array() {
   fi
 }
 
+validate_bastion_key_pair_configuration() {
+  local create_key_pair_variable=TF_VAR_create_new_key_pair
+
+  require_boolean_variable "${create_key_pair_variable}"
+  if [[ "${!create_key_pair_variable}" == true ]]; then
+    require_nonempty_variable TF_VAR_bastion_public_key
+  fi
+}
+
 validate_shared_environment() {
   local required_variable
   local required_variables=(
     TF_VAR_db_username
     TF_VAR_db_password
     TF_VAR_app_db_username
-    TF_VAR_bastion_public_key
     TF_VAR_bastion_key_name
     TF_VAR_alert_email
     TF_VAR_domain_name
@@ -65,7 +73,7 @@ validate_shared_environment() {
     require_nonempty_variable "${required_variable}"
   done
 
-  require_boolean_variable TF_VAR_create_new_key_pair
+  validate_bastion_key_pair_configuration
   require_nonempty_string_array TF_VAR_allowed_bastion_cidrs
   require_nonempty_string_array TF_VAR_allowed_lambda_cidrs
 }

--- a/.github/scripts/validate_terraform_environment_variables.sh
+++ b/.github/scripts/validate_terraform_environment_variables.sh
@@ -57,6 +57,16 @@ validate_bastion_key_pair_configuration() {
   fi
 }
 
+validate_repository_identity() {
+  require_nonempty_variable TF_VAR_github_repo
+  require_nonempty_variable GITHUB_REPOSITORY
+
+  if [[ "${TF_VAR_github_repo}" != "${GITHUB_REPOSITORY}" ]]; then
+    fail_validation 'RepositoryIdentityMismatch' TF_VAR_github_repo \
+      "configured repository must match the GitHub Actions repository"
+  fi
+}
+
 validate_shared_environment() {
   local required_variable
   local required_variables=(
@@ -66,7 +76,6 @@ validate_shared_environment() {
     TF_VAR_bastion_key_name
     TF_VAR_alert_email
     TF_VAR_domain_name
-    TF_VAR_github_repo
   )
 
   for required_variable in "${required_variables[@]}"; do
@@ -74,6 +83,7 @@ validate_shared_environment() {
   done
 
   validate_bastion_key_pair_configuration
+  validate_repository_identity
   require_nonempty_string_array TF_VAR_allowed_bastion_cidrs
   require_nonempty_string_array TF_VAR_allowed_lambda_cidrs
 }

--- a/.github/workflows/deploy_terraform_environment.yml
+++ b/.github/workflows/deploy_terraform_environment.yml
@@ -39,6 +39,7 @@ jobs:
       TF_VAR_ses_from_email: ${{ vars.SES_FROM_EMAIL }}
       TF_VAR_ses_notification_email: ${{ vars.SES_NOTIFICATION_EMAIL }}
       TF_VAR_bastion_key_name: ${{ vars.BASTION_KEY_NAME }}
+      TF_VAR_create_new_key_pair: ${{ vars.CREATE_NEW_KEY_PAIR }}
       TF_VAR_allowed_bastion_cidrs: ${{ vars.ALLOWED_BASTION_CIDRS }}
       TF_VAR_allowed_lambda_cidrs: ${{ vars.ALLOWED_LAMBDA_CIDRS }}
 
@@ -49,16 +50,7 @@ jobs:
       - name: Validate required variables
         env:
           AWS_ACCOUNT_ID: ${{ vars.AWS_ACCOUNT_ID }}
-          TF_PREFIX: ${{ vars.TF_VAR_PREFIX }}
-        run: |
-          if [[ -z "${AWS_ACCOUNT_ID}" ]]; then
-            echo "::error::AWS_ACCOUNT_ID is not set in the '${{ inputs.environment }}' GitHub environment"
-            exit 1
-          fi
-          if [[ -z "${TF_PREFIX}" ]]; then
-            echo "::error::TF_VAR_PREFIX is not set in the '${{ inputs.environment }}' GitHub environment"
-            exit 1
-          fi
+        run: .github/scripts/validate_terraform_environment_variables.sh "${{ inputs.environment }}"
 
       - name: Configure AWS credentials via OIDC
         uses: aws-actions/configure-aws-credentials@v4

--- a/.github/workflows/lint_shellcheck.yml
+++ b/.github/workflows/lint_shellcheck.yml
@@ -8,11 +8,13 @@ on:
     branches: [main]
     paths:
       - "**/*.sh"
+      - ".github/workflows/deploy_terraform_environment.yml"
       - ".github/workflows/lint_shellcheck.yml"
   pull_request:
     branches: [main]
     paths:
       - "**/*.sh"
+      - ".github/workflows/deploy_terraform_environment.yml"
       - ".github/workflows/lint_shellcheck.yml"
 
 jobs:

--- a/.github/workflows/lint_shellcheck.yml
+++ b/.github/workflows/lint_shellcheck.yml
@@ -33,5 +33,8 @@ jobs:
       - name: Test Terraform deployment environment selection
         run: .github/scripts/test_select_terraform_environments.sh
 
+      - name: Test Terraform deployment variable validation
+        run: .github/scripts/test_validate_terraform_environment_variables.sh
+
       - name: Test deployment workflow topology
         run: .github/scripts/test_deployment_workflows.sh

--- a/terraform/environments/prod/main.tf
+++ b/terraform/environments/prod/main.tf
@@ -300,9 +300,10 @@ resource "aws_iam_role_policy_attachment" "zappa_assets_access" {
 
 # Lambda ECR Module
 module "lambda_ecr" {
-  source      = "../../modules/lambda-ecr"
-  environment = "prod"
-  tags        = var.tags
+  source                = "../../modules/lambda-ecr"
+  environment           = "prod"
+  image_retention_count = 50
+  tags                  = var.tags
 }
 
 # ACM certificate for domain and all subdomains

--- a/terraform/environments/shared/variables.tf
+++ b/terraform/environments/shared/variables.tf
@@ -88,9 +88,9 @@ variable "db_allocated_storage" {
 }
 
 variable "db_engine_version" {
-  description = "Version of PostgreSQL to use"
+  description = "Major version of PostgreSQL to use; AWS manages patch upgrades"
   type        = string
-  default     = "16.9"
+  default     = "16"
 }
 
 variable "db_instance_class" {

--- a/terraform/modules/bastion/main.tf
+++ b/terraform/modules/bastion/main.tf
@@ -111,6 +111,7 @@ resource "aws_instance" "bastion" {
 
   lifecycle {
     create_before_destroy = true
+    ignore_changes        = [ami]
   }
 }
 

--- a/terraform/modules/lambda-ecr/main.tf
+++ b/terraform/modules/lambda-ecr/main.tf
@@ -43,11 +43,11 @@ resource "aws_ecr_lifecycle_policy" "lambda" {
     rules = [
       {
         rulePriority = 1
-        description  = "Keep last 10 images"
+        description  = "Keep the configured number of recent images"
         selection = {
           tagStatus   = "any"
           countType   = "imageCountMoreThan"
-          countNumber = 10
+          countNumber = var.image_retention_count
         }
         action = {
           type = "expire"

--- a/terraform/modules/lambda-ecr/variables.tf
+++ b/terraform/modules/lambda-ecr/variables.tf
@@ -8,3 +8,14 @@ variable "tags" {
   type        = map(string)
   default     = {}
 }
+
+variable "image_retention_count" {
+  description = "Number of recent Lambda images to retain for rollback"
+  type        = number
+  default     = 10
+
+  validation {
+    condition     = var.image_retention_count >= 1 && floor(var.image_retention_count) == var.image_retention_count
+    error_message = "image_retention_count must be a positive integer."
+  }
+}

--- a/terraform/modules/monitoring/main.tf
+++ b/terraform/modules/monitoring/main.tf
@@ -172,8 +172,6 @@ resource "aws_budgets_budget" "monthly" {
   limit_unit        = "USD"
   time_unit         = "MONTHLY"
   time_period_start = formatdate("YYYY-MM-01_00:00", timestamp())
-  # Add a reasonable end date (5 years in the future)
-  time_period_end = formatdate("YYYY-MM-01_00:00", timeadd(timestamp(), "43800h")) # ~5 years
 
   # Define cost types explicitly to avoid warnings
   cost_types {
@@ -227,7 +225,7 @@ resource "aws_budgets_budget" "monthly" {
   }
 
   lifecycle {
-    ignore_changes = [time_period_start, time_period_end]
+    ignore_changes = [time_period_start]
   }
 }
 

--- a/terraform/modules/monitoring/main.tf
+++ b/terraform/modules/monitoring/main.tf
@@ -225,6 +225,10 @@ resource "aws_budgets_budget" "monthly" {
   tags = {
     Name = "${var.prefix}-monthly-budget"
   }
+
+  lifecycle {
+    ignore_changes = [time_period_start, time_period_end]
+  }
 }
 
 # Cost Anomaly Detection
@@ -291,4 +295,3 @@ resource "awscc_ce_anomaly_subscription" "project_anomaly_subscription" {
   # Alert on anomalies with impact >= $5
   threshold = 5
 }
-

--- a/terraform/tests/modules/bastion_test.go
+++ b/terraform/tests/modules/bastion_test.go
@@ -1,12 +1,26 @@
 package modules
 
 import (
+	"os"
+	"regexp"
 	"testing"
 
 	"terraform-tests/common"
+
+	"github.com/stretchr/testify/assert"
 )
 
 // TestBastionModuleValidation runs validation-only tests that don't require AWS credentials
 func TestBastionModuleValidation(t *testing.T) {
 	common.ValidateModuleStructure(t, "bastion")
+}
+
+func TestBastionAMIRefreshDoesNotReplaceExistingInstance(t *testing.T) {
+	moduleSource, err := os.ReadFile("../../modules/bastion/main.tf")
+	assert.NoError(t, err)
+
+	amiLifecycleGuard := regexp.MustCompile(
+		`(?s)resource "aws_instance" "bastion".*?lifecycle \{.*?ignore_changes\s*=\s*\[ami\]`,
+	)
+	assert.Regexp(t, amiLifecycleGuard, string(moduleSource))
 }

--- a/terraform/tests/modules/database_test.go
+++ b/terraform/tests/modules/database_test.go
@@ -2,6 +2,9 @@ package modules
 
 import (
 	"fmt"
+	"os"
+	"regexp"
+	"strconv"
 	"testing"
 
 	"terraform-tests/common"
@@ -13,6 +16,21 @@ import (
 // TestDatabaseModuleValidation runs validation-only tests that don't require AWS credentials
 func TestDatabaseModuleValidation(t *testing.T) {
 	common.ValidateModuleStructure(t, "database")
+}
+
+func TestSharedDatabaseVersionAllowsAWSManagedPatches(t *testing.T) {
+	sharedVariablesSource, err := os.ReadFile("../../environments/shared/variables.tf")
+	assert.NoError(t, err)
+
+	versionDefault := regexp.MustCompile(
+		`(?s)variable "db_engine_version"\s*\{.*?default\s*=\s*"([^"]+)"`,
+	).FindStringSubmatch(string(sharedVariablesSource))
+	if assert.Len(t, versionDefault, 2) {
+		majorVersion, conversionError := strconv.Atoi(versionDefault[1])
+		if assert.NoError(t, conversionError, "shared database version must contain only a major version") {
+			assert.Positive(t, majorVersion)
+		}
+	}
 }
 
 func TestDatabaseModuleCreatesRDSInstance(t *testing.T) {

--- a/terraform/tests/modules/lambda_ecr_test.go
+++ b/terraform/tests/modules/lambda_ecr_test.go
@@ -17,9 +17,15 @@ func TestLambdaECRModuleValidation(t *testing.T) {
 func TestProductionRetainsFiftyRollbackImages(t *testing.T) {
 	productionSource, err := os.ReadFile("../../environments/prod/main.tf")
 	assert.NoError(t, err)
+	moduleSource, err := os.ReadFile("../../modules/lambda-ecr/main.tf")
+	assert.NoError(t, err)
 
 	productionRetention := regexp.MustCompile(
 		`(?s)module "lambda_ecr".*?image_retention_count\s*=\s*50`,
 	)
+	activeRetentionInput := regexp.MustCompile(
+		`(?s)resource "aws_ecr_lifecycle_policy" "lambda".*?countNumber\s*=\s*var\.image_retention_count`,
+	)
 	assert.Regexp(t, productionRetention, string(productionSource))
+	assert.Regexp(t, activeRetentionInput, string(moduleSource))
 }

--- a/terraform/tests/modules/lambda_ecr_test.go
+++ b/terraform/tests/modules/lambda_ecr_test.go
@@ -1,0 +1,25 @@
+package modules
+
+import (
+	"os"
+	"regexp"
+	"testing"
+
+	"terraform-tests/common"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestLambdaECRModuleValidation(t *testing.T) {
+	common.ValidateModuleStructure(t, "lambda-ecr")
+}
+
+func TestProductionRetainsFiftyRollbackImages(t *testing.T) {
+	productionSource, err := os.ReadFile("../../environments/prod/main.tf")
+	assert.NoError(t, err)
+
+	productionRetention := regexp.MustCompile(
+		`(?s)module "lambda_ecr".*?image_retention_count\s*=\s*50`,
+	)
+	assert.Regexp(t, productionRetention, string(productionSource))
+}

--- a/terraform/tests/modules/monitoring_test.go
+++ b/terraform/tests/modules/monitoring_test.go
@@ -3,7 +3,6 @@ package modules
 import (
 	"context"
 	"os"
-	"regexp"
 	"testing"
 
 	"terraform-tests/common"
@@ -25,12 +24,8 @@ func TestBudgetCalendarDatesDoNotCreatePerpetualDrift(t *testing.T) {
 	moduleSource, err := os.ReadFile("../../modules/monitoring/main.tf")
 	assert.NoError(t, err)
 
-	budgetResource := `(?s)resource "aws_budgets_budget" "monthly"`
-	ignoredCalendarDates := `.*?lifecycle \{.*?ignore_changes\s*=\s*\[time_period_start, time_period_end\]`
-	dateLifecycleGuard := regexp.MustCompile(
-		budgetResource + ignoredCalendarDates,
-	)
-	assert.Regexp(t, dateLifecycleGuard, string(moduleSource))
+	assert.NotContains(t, string(moduleSource), "time_period_end =")
+	assert.Contains(t, string(moduleSource), "ignore_changes = [time_period_start]")
 }
 
 func TestMonitoringModuleCreatesSNSTopics(t *testing.T) {

--- a/terraform/tests/modules/monitoring_test.go
+++ b/terraform/tests/modules/monitoring_test.go
@@ -2,6 +2,8 @@ package modules
 
 import (
 	"context"
+	"os"
+	"regexp"
 	"testing"
 
 	"terraform-tests/common"
@@ -17,6 +19,16 @@ import (
 // TestMonitoringModuleValidation runs validation-only tests that don't require AWS credentials
 func TestMonitoringModuleValidation(t *testing.T) {
 	common.ValidateModuleStructure(t, "monitoring")
+}
+
+func TestBudgetCalendarDatesDoNotCreatePerpetualDrift(t *testing.T) {
+	moduleSource, err := os.ReadFile("../../modules/monitoring/main.tf")
+	assert.NoError(t, err)
+
+	dateLifecycleGuard := regexp.MustCompile(
+		`(?s)resource "aws_budgets_budget" "monthly".*?lifecycle \{.*?ignore_changes\s*=\s*\[time_period_start, time_period_end\]`,
+	)
+	assert.Regexp(t, dateLifecycleGuard, string(moduleSource))
 }
 
 func TestMonitoringModuleCreatesSNSTopics(t *testing.T) {

--- a/terraform/tests/modules/monitoring_test.go
+++ b/terraform/tests/modules/monitoring_test.go
@@ -25,8 +25,10 @@ func TestBudgetCalendarDatesDoNotCreatePerpetualDrift(t *testing.T) {
 	moduleSource, err := os.ReadFile("../../modules/monitoring/main.tf")
 	assert.NoError(t, err)
 
+	budgetResource := `(?s)resource "aws_budgets_budget" "monthly"`
+	ignoredCalendarDates := `.*?lifecycle \{.*?ignore_changes\s*=\s*\[time_period_start, time_period_end\]`
 	dateLifecycleGuard := regexp.MustCompile(
-		`(?s)resource "aws_budgets_budget" "monthly".*?lifecycle \{.*?ignore_changes\s*=\s*\[time_period_start, time_period_end\]`,
+		budgetResource + ignoredCalendarDates,
 	)
 	assert.Regexp(t, dateLifecycleGuard, string(moduleSource))
 }


### PR DESCRIPTION
This change reconciles Terraform with resources that are already deployed and prevents missing shared-environment configuration from producing destructive plans. It also removes several sources of perpetual drift while preserving rollback capacity for production Lambda images.

## What this changes

The [reusable Terraform deployment workflow](https://github.com/lhadjchikh/coalition-builder/blob/agent/reconcile-terraform-drift/.github/workflows/deploy_terraform_environment.yml) now runs a [fail-closed input validator](https://github.com/lhadjchikh/coalition-builder/blob/agent/reconcile-terraform-drift/.github/scripts/validate_terraform_environment_variables.sh) before configuring AWS credentials or planning. Shared database, bastion, alerting, repository-identity, and network-boundary inputs must be present and structurally valid. Public-key material is required only when Terraform is creating a key pair.

Terraform now treats the shared PostgreSQL setting as a major-version constraint so AWS-managed patch upgrades do not look like downgrades. The bastion keeps its deployed AMI during routine plans, the monthly budget uses the provider's stable long-lived end date, and the production ECR policy retains 50 Lambda images for rollback. See the [shared environment variables](https://github.com/lhadjchikh/coalition-builder/blob/agent/reconcile-terraform-drift/terraform/environments/shared/variables.tf), [bastion module](https://github.com/lhadjchikh/coalition-builder/blob/agent/reconcile-terraform-drift/terraform/modules/bastion/main.tf), [monitoring module](https://github.com/lhadjchikh/coalition-builder/blob/agent/reconcile-terraform-drift/terraform/modules/monitoring/main.tf), and [ECR module](https://github.com/lhadjchikh/coalition-builder/blob/agent/reconcile-terraform-drift/terraform/modules/lambda-ecr/main.tf).

## Where to focus

### For human reviewers

- Confirm the shared input list matches the values whose absence could delete access rules, replace the bastion, or break future CI authentication.
- Review the lifecycle trade-offs: routine AMI drift is suppressed, while an intentional bastion refresh requires an explicit Terraform replacement.
- Confirm the state reconciliation and deployment order preserve existing live resources.

### For an AI review agent

- Adversarially test missing, empty, malformed, and conditionally required workflow inputs.
- Verify every changed Terraform parameter remains active and every lifecycle rule suppresses only the intended drift.
- Check that the regression tests fail when repository identity, key-pair behavior, major-only database versioning, workflow triggers, ECR retention, or budget lifecycle behavior regresses.

## Design notes

**Validation expands only where this incident occurred.** Shared-environment inputs receive the additional fail-closed checks; production and development retain their existing account and prefix validation.

**Routine AMI lookup changes do not replace the bastion.** An intentional upgrade remains possible with an explicit `terraform apply -replace=module.bastion.aws_instance.bastion` operation.

**State reconciliation was completed before merge.** Imports and the obsolete state-address removal were performed only after encrypted, versioned backups were created.

**Rollback images are retained before lifecycle enforcement.** Production keeps 50 recent Lambda images so applying the lifecycle policy does not immediately remove the existing rollback set.

## Initial reconciliation plans

The reconciliation plans generated before the final review fixes contained zero destroys:

- shared: 2 add, 31 in-place change, 0 destroy — [run 30663184054](https://github.com/lhadjchikh/coalition-builder/actions/runs/30663184054)
- production: 6 add, 5 in-place change, 0 destroy — [run 30664013331](https://github.com/lhadjchikh/coalition-builder/actions/runs/30664013331)
- development: 3 add, 2 in-place change, 0 destroy — [run 30663372103](https://github.com/lhadjchikh/coalition-builder/actions/runs/30663372103)

## Deployment order

1. Merge this before any other Terraform-changing PR.
2. Allow the merge workflow to apply shared, production, and development in sequence.
3. Confirm the alert-subscription messages sent to the configured operational recipient.

## Validation

- deployment workflow shell regression tests
- ShellCheck for the validator and workflow tests
- `terraform fmt -check -recursive terraform`
- `terraform validate` for shared, production, and development
- `go test -short ./modules -count=1`
- three full-diff review/triage cycles, ending with no new actionable findings
