### PR TITLE
Fix address autocomplete API routing

### DIFF
--- a/backend/coalition/api/address.py
+++ b/backend/coalition/api/address.py
@@ -13,7 +13,7 @@ logger = logging.getLogger(__name__)
 router = Router(tags=["Address"])
 
 
-@router.get("/suggestions", auth=None)
+@router.get("/suggestions/", auth=None)
 def get_address_suggestions(
     request: HttpRequest,
     q: str,
@@ -47,7 +47,7 @@ def get_address_suggestions(
         raise HttpError(500, "Failed to get address suggestions") from e
 
 
-@router.get("/place/{place_id}", auth=None)
+@router.get("/place/{place_id}/", auth=None)
 def get_place_details(
     request: HttpRequest,
     place_id: str,

--- a/backend/coalition/api/tests/test_address.py
+++ b/backend/coalition/api/tests/test_address.py
@@ -15,8 +15,11 @@ class TestAddressAPI(TestCase):
         self.client = TestClient(router)
 
     @patch("coalition.api.address.GeocodingService")
-    def test_get_address_suggestions_success(self, mock_geocoding_class: Any) -> None:
-        """Test successful address suggestions retrieval"""
+    def test_get_address_suggestions_success_with_proxied_path(
+        self,
+        mock_geocoding_class: Any,
+    ) -> None:
+        """Serve the trailing-slash path produced by the frontend API rewrite."""
         mock_service = MagicMock()
         mock_geocoding_class.return_value = mock_service
 
@@ -25,7 +28,7 @@ class TestAddressAPI(TestCase):
             {"text": "100 Congress St, Austin, TX 78701", "place_id": "place456"},
         ]
 
-        response = self.client.get("/suggestions?q=100 Congress")
+        response = self.client.get("/suggestions/?q=100 Congress")
 
         assert response.status_code == 200
         data = response.json()
@@ -49,7 +52,7 @@ class TestAddressAPI(TestCase):
             {"text": "Address 3", "place_id": "p3"},
         ]
 
-        response = self.client.get("/suggestions?q=test address&limit=3")
+        response = self.client.get("/suggestions/?q=test address&limit=3")
 
         assert response.status_code == 200
         data = response.json()
@@ -67,7 +70,7 @@ class TestAddressAPI(TestCase):
 
         mock_service.get_address_suggestions.return_value = []
 
-        response = self.client.get("/suggestions?q=test address&limit=20")
+        response = self.client.get("/suggestions/?q=test address&limit=20")
 
         assert response.status_code == 200
         # Verify limit was capped at 10
@@ -75,21 +78,21 @@ class TestAddressAPI(TestCase):
 
     def test_get_address_suggestions_short_query(self) -> None:
         """Test validation for short query string"""
-        response = self.client.get("/suggestions?q=ab")
+        response = self.client.get("/suggestions/?q=ab")
 
         assert response.status_code == 400
         assert "Query must be at least 3 characters" in response.json()["detail"]
 
     def test_get_address_suggestions_empty_query(self) -> None:
         """Test validation for empty query string"""
-        response = self.client.get("/suggestions?q=")
+        response = self.client.get("/suggestions/?q=")
 
         assert response.status_code == 400
         assert "Query must be at least 3 characters" in response.json()["detail"]
 
     def test_get_address_suggestions_whitespace_query(self) -> None:
         """Test validation for whitespace-only query"""
-        response = self.client.get("/suggestions?q=   ")
+        response = self.client.get("/suggestions/?q=   ")
 
         assert response.status_code == 400
         assert "Query must be at least 3 characters" in response.json()["detail"]
@@ -105,7 +108,7 @@ class TestAddressAPI(TestCase):
 
         mock_service.get_address_suggestions.return_value = []
 
-        response = self.client.get("/suggestions?q=  test query  ")
+        response = self.client.get("/suggestions/?q=  test query  ")
 
         assert response.status_code == 200
         # Verify query was stripped
@@ -122,7 +125,7 @@ class TestAddressAPI(TestCase):
 
         mock_service.get_address_suggestions.side_effect = Exception("Service error")
 
-        response = self.client.get("/suggestions?q=test query")
+        response = self.client.get("/suggestions/?q=test query")
 
         assert response.status_code == 500
         assert "Failed to get address suggestions" in response.json()["detail"]
@@ -138,7 +141,7 @@ class TestAddressAPI(TestCase):
 
         mock_service.get_address_suggestions.return_value = []
 
-        response = self.client.get("/suggestions?q=nonexistent address")
+        response = self.client.get("/suggestions/?q=nonexistent address")
 
         assert response.status_code == 200
         data = response.json()
@@ -159,7 +162,7 @@ class TestAddressAPI(TestCase):
             "country": "USA",
         }
 
-        response = self.client.get("/place/place123")
+        response = self.client.get("/place/place123/")
 
         assert response.status_code == 200
         data = response.json()
@@ -178,7 +181,7 @@ class TestAddressAPI(TestCase):
 
         mock_service.get_place_details.return_value = None
 
-        response = self.client.get("/place/nonexistent")
+        response = self.client.get("/place/nonexistent/")
 
         assert response.status_code == 404
         assert "Place not found" in response.json()["detail"]
@@ -203,7 +206,7 @@ class TestAddressAPI(TestCase):
 
         mock_service.get_place_details.side_effect = Exception("Service error")
 
-        response = self.client.get("/place/place123")
+        response = self.client.get("/place/place123/")
 
         assert response.status_code == 500
         assert "Failed to get place details" in response.json()["detail"]
@@ -226,7 +229,7 @@ class TestAddressAPI(TestCase):
         }
 
         place_id = "place_with-special.chars123"
-        response = self.client.get(f"/place/{place_id}")
+        response = self.client.get(f"/place/{place_id}/")
 
         assert response.status_code == 200
         mock_service.get_place_details.assert_called_once_with(place_id)
@@ -245,7 +248,7 @@ class TestAddressAPI(TestCase):
         error = Exception("Test error")
         mock_service.get_address_suggestions.side_effect = error
 
-        response = self.client.get("/suggestions?q=test")
+        response = self.client.get("/suggestions/?q=test")
 
         assert response.status_code == 500
         mock_logger.error.assert_called_once()
@@ -266,7 +269,7 @@ class TestAddressAPI(TestCase):
         error = Exception("Test error")
         mock_service.get_place_details.side_effect = error
 
-        response = self.client.get("/place/place123")
+        response = self.client.get("/place/place123/")
 
         assert response.status_code == 500
         mock_logger.error.assert_called_once()
@@ -287,8 +290,8 @@ class TestAddressAPI(TestCase):
         ]
 
         # Make multiple requests
-        response1 = self.client.get("/suggestions?q=query1")
-        response2 = self.client.get("/suggestions?q=query2&limit=7")
+        response1 = self.client.get("/suggestions/?q=query1")
+        response2 = self.client.get("/suggestions/?q=query2&limit=7")
 
         assert response1.status_code == 200
         assert response2.status_code == 200
@@ -307,7 +310,7 @@ class TestAddressAPI(TestCase):
 
         mock_service.get_address_suggestions.return_value = []
 
-        response = self.client.get("/suggestions?q=café street")
+        response = self.client.get("/suggestions/?q=café street")
 
         assert response.status_code == 200
         mock_service.get_address_suggestions.assert_called_once_with("café street", 5)
@@ -327,7 +330,7 @@ class TestAddressAPI(TestCase):
             "country": "USA",
         }
 
-        response = self.client.get("/place/place123")
+        response = self.client.get("/place/place123/")
 
         assert response.status_code == 200
         data = response.json()

--- a/frontend/components/AddressAutocomplete.tsx
+++ b/frontend/components/AddressAutocomplete.tsx
@@ -67,7 +67,7 @@ export default function AddressAutocomplete({
         setLoading(true);
         try {
           const response = await fetch(
-            `/api/address/suggestions?q=${encodeURIComponent(searchQuery)}&limit=5`
+            `/api/address/suggestions/?q=${encodeURIComponent(searchQuery)}&limit=5`
           );
 
           if (response.ok) {
@@ -105,7 +105,7 @@ export default function AddressAutocomplete({
     // Fetch detailed address components
     try {
       const response = await fetch(
-        `/api/address/place/${encodeURIComponent(suggestion.place_id)}`
+        `/api/address/place/${encodeURIComponent(suggestion.place_id)}/`
       );
 
       if (response.ok) {

--- a/frontend/components/__tests__/AddressAutocomplete.test.tsx
+++ b/frontend/components/__tests__/AddressAutocomplete.test.tsx
@@ -1,0 +1,81 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+
+import AddressAutocomplete from "../AddressAutocomplete";
+
+describe("AddressAutocomplete", () => {
+  const fetchMock = jest.fn();
+
+  beforeEach(() => {
+    fetchMock.mockReset();
+    global.fetch = fetchMock;
+  });
+
+  it("requests suggestions from the trailing-slash API route", async () => {
+    fetchMock.mockResolvedValue({
+      ok: true,
+      json: async () => ({ suggestions: [] }),
+    } as Response);
+
+    render(
+      <AddressAutocomplete onAddressSelect={jest.fn()} debounceDelay={0} />
+    );
+
+    fireEvent.change(screen.getByTestId("address-autocomplete"), {
+      target: { value: "100 Main" },
+    });
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith(
+        "/api/address/suggestions/?q=100%20Main&limit=5"
+      );
+    });
+  });
+
+  it("requests place details from the trailing-slash API route", async () => {
+    const onAddressSelect = jest.fn();
+    fetchMock
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          suggestions: [{ text: "100 Main St", place_id: "place-123" }],
+        }),
+      } as Response)
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          street_address: "100 Main St",
+          city: "Baltimore",
+          state: "MD",
+          zip_code: "21201",
+        }),
+      } as Response);
+
+    render(
+      <AddressAutocomplete
+        onAddressSelect={onAddressSelect}
+        debounceDelay={0}
+      />
+    );
+
+    fireEvent.change(screen.getByTestId("address-autocomplete"), {
+      target: { value: "100 Main" },
+    });
+    await waitFor(() => {
+      expect(screen.getByTestId("suggestion-0")).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByTestId("suggestion-0"));
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenLastCalledWith(
+        "/api/address/place/place-123/"
+      );
+      expect(onAddressSelect).toHaveBeenCalledWith({
+        street_address: "100 Main St",
+        city: "Baltimore",
+        state: "MD",
+        zip_code: "21201",
+      });
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- align the address suggestions and place-details endpoints with the trailing-slash convention used by the Next.js API proxy
- update the autocomplete client to request the canonical endpoint URLs directly
- add regression coverage for suggestion lookup, place-detail lookup, and the proxied backend paths

## Root cause

The Next.js catch-all rewrite normalizes API requests to trailing-slash Django paths, but the address router registered its leaf routes without trailing slashes. Requests from the endorsement form therefore reached `/api/address/suggestions/`, which did not match the backend route and returned 404.

## Impact

Address suggestions can load again on the endorsement form, and selecting a suggestion can retrieve its structured address details without encountering the same route mismatch.

## Validation

- `poetry run pytest coalition/api/tests/test_address.py -q --no-cov` — 19 passed
- `npm test -- --runInBand` — 476 passed, 29 skipped
- `npm run typecheck`
- ESLint on the changed frontend files
- Ruff and Black checks on the changed backend files
- exact request through the local Next.js proxy returned HTTP 200