### PR TITLE
Configure AWS Location index for Lambda

### DIFF
--- a/.github/scripts/test_deployment_workflows.sh
+++ b/.github/scripts/test_deployment_workflows.sh
@@ -85,6 +85,14 @@ require_text "${lambda_workflow}" "collectstatic --noinput"
 require_text "${lambda_workflow}" "--connect-timeout 5"
 require_text "${lambda_workflow}" "--max-time 15"
 require_text "${lambda_workflow}" "\${DEPLOYMENT_API_URL%/}/api/health/"
+require_step_text \
+  "${lambda_workflow}" \
+  "Validate required configuration" \
+  'AWS_LOCATION_PLACE_INDEX_NAME: ${{ vars.AWS_LOCATION_PLACE_INDEX_NAME }}'
+require_step_text \
+  "${lambda_workflow}" \
+  "Configure Zappa settings" \
+  'AWS_LOCATION_PLACE_INDEX_NAME: ${{ vars.AWS_LOCATION_PLACE_INDEX_NAME }}'
 
 require_text "${frontend_workflow}" 'group: deploy-frontend-'
 require_text "${frontend_workflow}" "cancel-in-progress: false"
@@ -95,6 +103,14 @@ require_text "${management_workflow}" "role-to-assume:"
 reject_text "${management_workflow}" "aws-access-key-id:"
 reject_text "${management_workflow}" "aws-secret-access-key:"
 require_text "${management_workflow}" "scripts/configure_zappa.py"
+require_step_text \
+  "${management_workflow}" \
+  "Validate required configuration" \
+  'AWS_LOCATION_PLACE_INDEX_NAME: ${{ vars.AWS_LOCATION_PLACE_INDEX_NAME }}'
+require_step_text \
+  "${management_workflow}" \
+  "Configure Zappa settings" \
+  'AWS_LOCATION_PLACE_INDEX_NAME: ${{ vars.AWS_LOCATION_PLACE_INDEX_NAME }}'
 
 require_text "${terraform_workflow}" "TF_VAR_create_new_key_pair: \${{ vars.CREATE_NEW_KEY_PAIR }}"
 require_text "${terraform_workflow}" "validate_terraform_environment_variables.sh"

--- a/.github/workflows/deploy_lambda.yml
+++ b/.github/workflows/deploy_lambda.yml
@@ -46,6 +46,7 @@ jobs:
       - name: Validate required configuration
         env:
           AWS_ACCOUNT_ID: ${{ vars.AWS_ACCOUNT_ID }}
+          AWS_LOCATION_PLACE_INDEX_NAME: ${{ vars.AWS_LOCATION_PLACE_INDEX_NAME }}
           AWS_STORAGE_BUCKET_NAME: ${{ vars.AWS_STORAGE_BUCKET_NAME }}
           CLOUDFRONT_DOMAIN: ${{ vars.CLOUDFRONT_DOMAIN }}
           DATABASE_SECRET_ARN: ${{ secrets.DATABASE_SECRET_ARN }}
@@ -58,6 +59,7 @@ jobs:
         run: |
           required_names=(
             AWS_ACCOUNT_ID
+            AWS_LOCATION_PLACE_INDEX_NAME
             AWS_STORAGE_BUCKET_NAME
             DATABASE_SECRET_ARN
             DEPLOYMENT_API_URL
@@ -181,6 +183,7 @@ jobs:
         working-directory: ./backend
         env:
           AWS_ACCOUNT_ID: ${{ vars.AWS_ACCOUNT_ID }}
+          AWS_LOCATION_PLACE_INDEX_NAME: ${{ vars.AWS_LOCATION_PLACE_INDEX_NAME }}
           AWS_REGION: us-east-1
           ZAPPA_S3_BUCKET: ${{ vars.ZAPPA_S3_BUCKET }}
           DEPLOYMENT_ENVIRONMENT: ${{ steps.deployment_environment.outputs.environment }}

--- a/.github/workflows/lambda_management.yml
+++ b/.github/workflows/lambda_management.yml
@@ -52,6 +52,7 @@ jobs:
       - name: Validate required configuration
         env:
           AWS_ACCOUNT_ID: ${{ vars.AWS_ACCOUNT_ID }}
+          AWS_LOCATION_PLACE_INDEX_NAME: ${{ vars.AWS_LOCATION_PLACE_INDEX_NAME }}
           AWS_STORAGE_BUCKET_NAME: ${{ vars.AWS_STORAGE_BUCKET_NAME }}
           DATABASE_SECRET_ARN: ${{ secrets.DATABASE_SECRET_ARN }}
           DJANGO_SECRET_ARN: ${{ secrets.DJANGO_SECRET_ARN }}
@@ -60,6 +61,7 @@ jobs:
         run: |
           required_names=(
             AWS_ACCOUNT_ID
+            AWS_LOCATION_PLACE_INDEX_NAME
             AWS_STORAGE_BUCKET_NAME
             DATABASE_SECRET_ARN
             DJANGO_SECRET_ARN
@@ -100,6 +102,7 @@ jobs:
         working-directory: ./backend
         env:
           AWS_ACCOUNT_ID: ${{ vars.AWS_ACCOUNT_ID }}
+          AWS_LOCATION_PLACE_INDEX_NAME: ${{ vars.AWS_LOCATION_PLACE_INDEX_NAME }}
           AWS_REGION: us-east-1
           AWS_STORAGE_BUCKET_NAME: ${{ vars.AWS_STORAGE_BUCKET_NAME }}
           CLOUDFRONT_DOMAIN: ${{ vars.CLOUDFRONT_DOMAIN }}

--- a/backend/scripts/configure_zappa.py
+++ b/backend/scripts/configure_zappa.py
@@ -73,6 +73,19 @@ def with_stage_cloudfront_domain(
     return environment_variables
 
 
+def with_location_place_index(
+    environment_variables: dict[str, str],
+    place_index_name: str,
+) -> dict[str, str]:
+    """Return Lambda env vars with the configured AWS Location place index."""
+    if place_index_name:
+        return {
+            **environment_variables,
+            "AWS_LOCATION_PLACE_INDEX_NAME": place_index_name,
+        }
+    return environment_variables
+
+
 def configure_zappa_settings(output_path: Path | None = None) -> None:
     """Generate zappa_settings.json from environment variables."""
 
@@ -102,6 +115,9 @@ def configure_zappa_settings(output_path: Path | None = None) -> None:
     )
     selected_assets_bucket = get_env_or_default("AWS_STORAGE_BUCKET_NAME")
     cloudfront_domain = get_env_or_default("CLOUDFRONT_DOMAIN")
+    location_place_index_name = get_env_or_default(
+        "AWS_LOCATION_PLACE_INDEX_NAME",
+    ).strip()
     active_stage_names = DEV_STAGE_NAMES | PROD_STAGE_NAMES
     if enable_staging:
         active_stage_names = active_stage_names | STAGING_STAGE_NAMES
@@ -159,6 +175,7 @@ def configure_zappa_settings(output_path: Path | None = None) -> None:
                 ("DATABASE_SECRET_ARN", db_secret_arn),
                 ("DJANGO_SECRET_ARN", django_secret_arn),
                 ("ZAPPA_ROLE_NAME", zappa_role_name),
+                ("AWS_LOCATION_PLACE_INDEX_NAME", location_place_index_name),
             )
             if not value
         ]
@@ -223,14 +240,17 @@ def configure_zappa_settings(output_path: Path | None = None) -> None:
             "timeout_seconds": 30,
             "slim_handler": False,
             "use_precompiled_packages": False,
-            "environment_variables": {
-                "USE_S3": "true",
-                "IS_LAMBDA": "true",
-                "USE_GEODJANGO": "true",
-                "GDAL_DATA": "/opt/share/gdal",
-                "PROJ_LIB": "/opt/share/proj",
-                "LD_LIBRARY_PATH": "/opt/lib:/opt/lib64",
-            },
+            "environment_variables": with_location_place_index(
+                {
+                    "USE_S3": "true",
+                    "IS_LAMBDA": "true",
+                    "USE_GEODJANGO": "true",
+                    "GDAL_DATA": "/opt/share/gdal",
+                    "PROJ_LIB": "/opt/share/proj",
+                    "LD_LIBRARY_PATH": "/opt/lib:/opt/lib64",
+                },
+                location_place_index_name,
+            ),
             "exclude": [
                 "*.gz",
                 "*.rar",

--- a/backend/scripts/tests/test_configure_zappa.py
+++ b/backend/scripts/tests/test_configure_zappa.py
@@ -109,9 +109,7 @@ class TestLocationConfiguration:
         )
 
         assert (
-            settings["base"]["environment_variables"][
-                "AWS_LOCATION_PLACE_INDEX_NAME"
-            ]
+            settings["base"]["environment_variables"]["AWS_LOCATION_PLACE_INDEX_NAME"]
             == "landandbay-geocoding-index"
         )
 

--- a/backend/scripts/tests/test_configure_zappa.py
+++ b/backend/scripts/tests/test_configure_zappa.py
@@ -95,6 +95,39 @@ class TestProvidedSecretARNs:
         assert settings["prod"]["aws_environment_variables"]["SECRET_KEY"] == arn
 
 
+class TestLocationConfiguration:
+    """Tests for the AWS Location place index in generated settings."""
+
+    def test_place_index_name_is_added_to_lambda_environment(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """The configured place index must be available to the geocoding service."""
+        settings = _generate_settings(
+            tmp_path,
+            {"AWS_LOCATION_PLACE_INDEX_NAME": "landandbay-geocoding-index"},
+        )
+
+        assert (
+            settings["base"]["environment_variables"][
+                "AWS_LOCATION_PLACE_INDEX_NAME"
+            ]
+            == "landandbay-geocoding-index"
+        )
+
+    def test_unconfigured_place_index_is_omitted_outside_ci(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """Local settings should not contain a misleading empty index name."""
+        settings = _generate_settings(tmp_path)
+
+        assert (
+            "AWS_LOCATION_PLACE_INDEX_NAME"
+            not in settings["base"]["environment_variables"]
+        )
+
+
 class TestAssetConfiguration:
     """Tests for media bucket environment variables."""
 
@@ -347,6 +380,22 @@ class TestCIValidation:
                 },
             )
 
+    def test_ci_raises_when_location_place_index_name_missing(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """In CI, missing AWS_LOCATION_PLACE_INDEX_NAME should raise."""
+        with pytest.raises(RuntimeError, match="AWS_LOCATION_PLACE_INDEX_NAME"):
+            _generate_settings(
+                tmp_path,
+                {
+                    "CI": "true",
+                    "DATABASE_SECRET_ARN": self._arn,
+                    "DJANGO_SECRET_ARN": self._arn,
+                    "ZAPPA_ROLE_NAME": "my-role",
+                },
+            )
+
     def test_ci_succeeds_when_all_required_vars_provided(
         self,
         tmp_path: Path,
@@ -359,6 +408,7 @@ class TestCIValidation:
                 "DATABASE_SECRET_ARN": self._arn,
                 "DJANGO_SECRET_ARN": self._arn,
                 "ZAPPA_ROLE_NAME": "my-role",
+                "AWS_LOCATION_PLACE_INDEX_NAME": "landandbay-geocoding-index",
             },
         )
         db_url = settings["prod"]["aws_environment_variables"]

--- a/docs/serverless-setup.md
+++ b/docs/serverless-setup.md
@@ -21,6 +21,7 @@ export AWS_REGION="us-east-1"
 export ZAPPA_DEPLOYMENT_BUCKET="coalition-zappa-deployments-abc123"
 export DEPLOYMENT_ENVIRONMENT="dev"
 export AWS_STORAGE_BUCKET_NAME="coalition-dev-assets-abc123"
+export AWS_LOCATION_PLACE_INDEX_NAME="coalition-geocoding-index"
 
 # Optional - Database names (defaults shown)
 export DEV_DB_NAME="coalition_dev"
@@ -71,6 +72,7 @@ For CI/CD, add these as GitHub Secrets:
 
 - `ZAPPA_DEPLOYMENT_BUCKET`
 - `AWS_STORAGE_BUCKET_NAME` (set separately in each GitHub Environment)
+- `AWS_LOCATION_PLACE_INDEX_NAME` (use the matching environment's Terraform `location_place_index_name` output)
 
 ### Optional Variables
 
@@ -97,11 +99,13 @@ the bucket name from its outputs:
 ```bash
 cd terraform/environments/dev
 terraform output -raw serverless_bucket_name   # -> AWS_STORAGE_BUCKET_NAME
+terraform output -raw location_place_index_name # -> AWS_LOCATION_PLACE_INDEX_NAME
 ```
 
-Set the dev environment's `AWS_STORAGE_BUCKET_NAME` to that bucket. Dev serves media
-directly from S3, so `CLOUDFRONT_DOMAIN` is left unset. (Staging is generated as an
-optional Zappa stage via `ENABLE_STAGING`, not a separate environment directory.)
+Set the dev environment's `AWS_STORAGE_BUCKET_NAME` and
+`AWS_LOCATION_PLACE_INDEX_NAME` to those outputs. Dev serves media directly from
+S3, so `CLOUDFRONT_DOMAIN` is left unset. (Staging is generated as an optional
+Zappa stage via `ENABLE_STAGING`, not a separate environment directory.)
 
 ### Production (`module.storage`)
 
@@ -114,11 +118,12 @@ attachment and Django cannot write to it.
 cd terraform/environments/prod
 terraform output static_assets_bucket_name         # -> AWS_STORAGE_BUCKET_NAME
 terraform output cloudfront_distribution_domain_name  # -> CLOUDFRONT_DOMAIN
+terraform output -raw location_place_index_name     # -> AWS_LOCATION_PLACE_INDEX_NAME
 ```
 
-Set the prod GitHub environment's `AWS_STORAGE_BUCKET_NAME` and `CLOUDFRONT_DOMAIN`
-variables to these two outputs so Lambda writes to, and Django serves from, the same
-bucket that is fronted by CloudFront.
+Set the prod GitHub environment's `AWS_STORAGE_BUCKET_NAME`, `CLOUDFRONT_DOMAIN`,
+and `AWS_LOCATION_PLACE_INDEX_NAME` variables to these outputs. The place index
+variable enables address autocomplete and geocoding in Lambda.
 
 ## Configuration Options
 

--- a/terraform/environments/dev/outputs.tf
+++ b/terraform/environments/dev/outputs.tf
@@ -43,6 +43,11 @@ output "lambda_security_group_id" {
   value       = module.zappa.lambda_security_group_id
 }
 
+output "location_place_index_name" {
+  description = "AWS Location place index name. Set the dev GitHub environment's AWS_LOCATION_PLACE_INDEX_NAME variable to this value."
+  value       = module.aws_location.place_index_name
+}
+
 # ECR
 output "geolambda_repository_url" {
   description = "URL of the geolambda ECR repository"

--- a/terraform/environments/prod/outputs.tf
+++ b/terraform/environments/prod/outputs.tf
@@ -37,6 +37,11 @@ output "lambda_security_group_id" {
   value       = module.zappa.lambda_security_group_id
 }
 
+output "location_place_index_name" {
+  description = "AWS Location place index name. Set the prod GitHub environment's AWS_LOCATION_PLACE_INDEX_NAME variable to this value."
+  value       = module.aws_location.place_index_name
+}
+
 # ECR
 output "geolambda_repository_url" {
   description = "URL of the geolambda ECR repository"


### PR DESCRIPTION
## Summary

- require the AWS Location place-index name in Lambda deployment and management workflows
- propagate the configured index into the generated Zappa/Lambda environment
- expose the place-index name from the dev and production Terraform roots
- add regression coverage and setup documentation

## Root cause

The address routes were deployed successfully, but `AWS_LOCATION_PLACE_INDEX_NAME` was never passed to `configure_zappa.py`. `GeocodingService` therefore disabled its AWS Location client and returned an empty suggestions list, making the endpoint look healthy while autocomplete remained unusable.

## Impact

After this change deploys, the Lambda can initialize AWS Location and return address suggestions. Future deployments fail before changing Lambda if the required place-index setting is absent.

## Deployment configuration

`AWS_LOCATION_PLACE_INDEX_NAME=landandbay-geocoding-index` is configured in the `dev` and `prod` GitHub environments. The `test` environment does not deploy or generate Zappa settings and does not require it.

## Validation

- `poetry run pytest scripts/tests/test_configure_zappa.py -q --no-cov`
- `poetry run ruff check scripts/configure_zappa.py scripts/tests/test_configure_zappa.py`
- `poetry run mypy scripts/configure_zappa.py scripts/tests/test_configure_zappa.py`
- `bash .github/scripts/test_deployment_workflows.sh`
- `terraform fmt -check terraform/environments/dev/outputs.tf terraform/environments/prod/outputs.tf`
- `git diff --check`