### PR TITLE
Fix address suggestions in Lambda deployments

### DIFF
--- a/.github/scripts/test_deployment_workflows.sh
+++ b/.github/scripts/test_deployment_workflows.sh
@@ -104,7 +104,11 @@ require_step_text \
 require_step_text \
   "${lambda_workflow}" \
   "Verify deployed address configuration" \
-  'DEPLOYED_PLACE_INDEX_NAME'
+  'if [[ "${DEPLOYED_PLACE_INDEX_NAME}" != "${AWS_LOCATION_PLACE_INDEX_NAME}" ]]; then'
+require_step_text \
+  "${lambda_workflow}" \
+  "Verify deployed address configuration" \
+  'exit 1'
 
 require_text "${frontend_workflow}" 'group: deploy-frontend-'
 require_text "${frontend_workflow}" "cancel-in-progress: false"

--- a/.github/scripts/test_deployment_workflows.sh
+++ b/.github/scripts/test_deployment_workflows.sh
@@ -96,6 +96,10 @@ require_step_text \
 require_step_text \
   "${lambda_workflow}" \
   "Verify deployed address configuration" \
+  'aws lambda wait function-updated'
+require_step_text \
+  "${lambda_workflow}" \
+  "Verify deployed address configuration" \
   'Environment.Variables.AWS_LOCATION_PLACE_INDEX_NAME'
 require_step_text \
   "${lambda_workflow}" \

--- a/.github/scripts/test_deployment_workflows.sh
+++ b/.github/scripts/test_deployment_workflows.sh
@@ -93,6 +93,14 @@ require_step_text \
   "${lambda_workflow}" \
   "Configure Zappa settings" \
   'AWS_LOCATION_PLACE_INDEX_NAME: ${{ vars.AWS_LOCATION_PLACE_INDEX_NAME }}'
+require_step_text \
+  "${lambda_workflow}" \
+  "Verify deployed address configuration" \
+  'Environment.Variables.AWS_LOCATION_PLACE_INDEX_NAME'
+require_step_text \
+  "${lambda_workflow}" \
+  "Verify deployed address configuration" \
+  'DEPLOYED_PLACE_INDEX_NAME'
 
 require_text "${frontend_workflow}" 'group: deploy-frontend-'
 require_text "${frontend_workflow}" "cancel-in-progress: false"

--- a/.github/workflows/deploy_lambda.yml
+++ b/.github/workflows/deploy_lambda.yml
@@ -287,6 +287,8 @@ jobs:
           AWS_LOCATION_PLACE_INDEX_NAME: ${{ vars.AWS_LOCATION_PLACE_INDEX_NAME }}
           DEPLOYMENT_ENVIRONMENT: ${{ steps.deployment_environment.outputs.environment }}
         run: |
+          aws lambda wait function-updated --function-name "coalition-${DEPLOYMENT_ENVIRONMENT}"
+
           DEPLOYED_PLACE_INDEX_NAME=$(aws lambda get-function-configuration \
             --function-name "coalition-${DEPLOYMENT_ENVIRONMENT}" \
             --query 'Environment.Variables.AWS_LOCATION_PLACE_INDEX_NAME' \

--- a/.github/workflows/deploy_lambda.yml
+++ b/.github/workflows/deploy_lambda.yml
@@ -282,6 +282,21 @@ jobs:
           aws lambda wait function-updated --function-name "coalition-${DEPLOYMENT_ENVIRONMENT}"
           poetry run zappa update "${DEPLOYMENT_ENVIRONMENT}" --docker-image-uri "${IMAGE_URI}"
 
+      - name: Verify deployed address configuration
+        env:
+          AWS_LOCATION_PLACE_INDEX_NAME: ${{ vars.AWS_LOCATION_PLACE_INDEX_NAME }}
+          DEPLOYMENT_ENVIRONMENT: ${{ steps.deployment_environment.outputs.environment }}
+        run: |
+          DEPLOYED_PLACE_INDEX_NAME=$(aws lambda get-function-configuration \
+            --function-name "coalition-${DEPLOYMENT_ENVIRONMENT}" \
+            --query 'Environment.Variables.AWS_LOCATION_PLACE_INDEX_NAME' \
+            --output text)
+
+          if [[ "${DEPLOYED_PLACE_INDEX_NAME}" != "${AWS_LOCATION_PLACE_INDEX_NAME}" ]]; then
+            echo "::error::Deployed Lambda is missing the configured AWS Location place index"
+            exit 1
+          fi
+
       - name: Create cache table
         working-directory: ./backend
         env:

--- a/.github/workflows/lambda_management.yml
+++ b/.github/workflows/lambda_management.yml
@@ -128,7 +128,7 @@ jobs:
               --since 1h \
               --format short
             echo '```'
-          } >> "${GITHUB_STEP_SUMMARY}"
+          } | tee -a "${GITHUB_STEP_SUMMARY}"
 
       - name: Roll back deployment
         if: github.event.inputs.action == 'rollback'

--- a/backend/coalition/stakeholders/services.py
+++ b/backend/coalition/stakeholders/services.py
@@ -23,6 +23,10 @@ AWS_LOCATION_CONFIDENCE_THRESHOLD = float(
 )
 
 
+class AddressSuggestionsUnavailableError(RuntimeError):
+    """Raised when the configured address-suggestion provider cannot respond."""
+
+
 class GeocodingService:
     """Service for geocoding addresses and assigning legislative districts"""
 
@@ -96,8 +100,9 @@ class GeocodingService:
         Returns a list of suggested addresses with structured components.
         """
         if not self.location_client or not self.place_index_name:
-            logger.warning("AWS Location Service not available for suggestions")
-            return []
+            raise AddressSuggestionsUnavailableError(
+                "AWS Location Service is not configured for address suggestions",
+            )
 
         try:
             response = self.location_client.search_place_index_for_suggestions(
@@ -118,12 +123,16 @@ class GeocodingService:
 
             return suggestions
 
-        except ClientError as e:
-            logger.error(f"Failed to get address suggestions: {e}")
-            return []
-        except Exception as e:
-            logger.error(f"Unexpected error getting suggestions: {e}")
-            return []
+        except ClientError as error:
+            logger.exception("AWS Location address-suggestion request failed")
+            raise AddressSuggestionsUnavailableError(
+                "AWS Location failed to provide address suggestions",
+            ) from error
+        except Exception as error:
+            logger.exception("Unexpected address-suggestion provider failure")
+            raise AddressSuggestionsUnavailableError(
+                "Address suggestion provider failed unexpectedly",
+            ) from error
 
     def get_place_details(self, place_id: str) -> dict[str, str] | None:
         """

--- a/backend/coalition/stakeholders/tests/test_services.py
+++ b/backend/coalition/stakeholders/tests/test_services.py
@@ -6,7 +6,10 @@ from django.contrib.gis.geos import Point
 
 from coalition.regions.models import Region
 from coalition.stakeholders.models import Stakeholder
-from coalition.stakeholders.services import GeocodingService
+from coalition.stakeholders.services import (
+    AddressSuggestionsUnavailableError,
+    GeocodingService,
+)
 from coalition.test_base import BaseTestCase
 
 
@@ -394,9 +397,8 @@ class TestGeocodingService(BaseTestCase):
         """Test getting suggestions when AWS Location client is not available"""
         self.geocoding_service.location_client = None
 
-        suggestions = self.geocoding_service.get_address_suggestions("100 Congress")
-
-        assert suggestions == []
+        with self.assertRaises(AddressSuggestionsUnavailableError):
+            self.geocoding_service.get_address_suggestions("100 Congress")
 
     @patch("coalition.stakeholders.services.boto3")
     def test_get_address_suggestions_with_client_error(self, mock_boto3: Any) -> None:
@@ -415,9 +417,8 @@ class TestGeocodingService(BaseTestCase):
         self.geocoding_service.location_client = mock_client
         self.geocoding_service.place_index_name = "test-index"
 
-        suggestions = self.geocoding_service.get_address_suggestions("100 Congress")
-
-        assert suggestions == []
+        with self.assertRaises(AddressSuggestionsUnavailableError):
+            self.geocoding_service.get_address_suggestions("100 Congress")
 
     @patch("coalition.stakeholders.services.boto3")
     def test_get_address_suggestions_with_unexpected_error(
@@ -435,9 +436,8 @@ class TestGeocodingService(BaseTestCase):
         self.geocoding_service.location_client = mock_client
         self.geocoding_service.place_index_name = "test-index"
 
-        suggestions = self.geocoding_service.get_address_suggestions("100 Congress")
-
-        assert suggestions == []
+        with self.assertRaises(AddressSuggestionsUnavailableError):
+            self.geocoding_service.get_address_suggestions("100 Congress")
 
     def test_get_place_details_without_client(self) -> None:
         """Test getting place details when AWS Location client is not available"""

--- a/backend/scripts/configure_zappa.py
+++ b/backend/scripts/configure_zappa.py
@@ -200,8 +200,20 @@ def configure_zappa_settings(output_path: Path | None = None) -> None:
         dev_docker_image = "public.ecr.aws/lambda/python:3.13"
         production_docker_image = "public.ecr.aws/lambda/python:3.13"
 
+    runtime_environment_variables = with_location_place_index(
+        {
+            "USE_S3": "true",
+            "IS_LAMBDA": "true",
+            "USE_GEODJANGO": "true",
+            "GDAL_DATA": "/opt/share/gdal",
+            "PROJ_LIB": "/opt/share/proj",
+            "LD_LIBRARY_PATH": "/opt/lib:/opt/lib64",
+        },
+        location_place_index_name,
+    )
     dev_environment_variables = with_stage_cloudfront_domain(
         {
+            **runtime_environment_variables,
             "ENVIRONMENT": "dev",
             "DEBUG": "true",
             "DATABASE_NAME": dev_db_name,
@@ -213,6 +225,7 @@ def configure_zappa_settings(output_path: Path | None = None) -> None:
     )
     production_environment_variables = with_stage_cloudfront_domain(
         {
+            **runtime_environment_variables,
             "ENVIRONMENT": "production",
             "DEBUG": "false",
             "DATABASE_NAME": production_db_name,
@@ -240,17 +253,6 @@ def configure_zappa_settings(output_path: Path | None = None) -> None:
             "timeout_seconds": 30,
             "slim_handler": False,
             "use_precompiled_packages": False,
-            "environment_variables": with_location_place_index(
-                {
-                    "USE_S3": "true",
-                    "IS_LAMBDA": "true",
-                    "USE_GEODJANGO": "true",
-                    "GDAL_DATA": "/opt/share/gdal",
-                    "PROJ_LIB": "/opt/share/proj",
-                    "LD_LIBRARY_PATH": "/opt/lib:/opt/lib64",
-                },
-                location_place_index_name,
-            ),
             "exclude": [
                 "*.gz",
                 "*.rar",
@@ -338,6 +340,7 @@ def configure_zappa_settings(output_path: Path | None = None) -> None:
 
         staging_environment_variables = with_stage_cloudfront_domain(
             {
+                **runtime_environment_variables,
                 "ENVIRONMENT": "staging",
                 "DEBUG": "false",
                 "DATABASE_NAME": staging_db_name,

--- a/backend/scripts/configure_zappa.py
+++ b/backend/scripts/configure_zappa.py
@@ -200,14 +200,18 @@ def configure_zappa_settings(output_path: Path | None = None) -> None:
         dev_docker_image = "public.ecr.aws/lambda/python:3.13"
         production_docker_image = "public.ecr.aws/lambda/python:3.13"
 
-    runtime_environment_variables = with_location_place_index(
+    runtime_environment_variables = {
+        "USE_S3": "true",
+        "IS_LAMBDA": "true",
+        "USE_GEODJANGO": "true",
+        "GDAL_DATA": "/opt/share/gdal",
+        "PROJ_LIB": "/opt/share/proj",
+        "LD_LIBRARY_PATH": "/opt/lib:/opt/lib64",
+    }
+    aws_environment_variables = with_location_place_index(
         {
-            "USE_S3": "true",
-            "IS_LAMBDA": "true",
-            "USE_GEODJANGO": "true",
-            "GDAL_DATA": "/opt/share/gdal",
-            "PROJ_LIB": "/opt/share/proj",
-            "LD_LIBRARY_PATH": "/opt/lib:/opt/lib64",
+            "DATABASE_URL": db_secret_arn,
+            "SECRET_KEY": django_secret_arn,
         },
         location_place_index_name,
     )
@@ -291,10 +295,7 @@ def configure_zappa_settings(output_path: Path | None = None) -> None:
             "memory_size": 512,
             "keep_warm": False,
             "environment_variables": dev_environment_variables,
-            "aws_environment_variables": {
-                "DATABASE_URL": db_secret_arn,
-                "SECRET_KEY": django_secret_arn,
-            },
+            "aws_environment_variables": aws_environment_variables,
             "apigateway_settings": {
                 "throttle_burst_limit": 50,
                 "throttle_rate_limit": 25,
@@ -308,10 +309,7 @@ def configure_zappa_settings(output_path: Path | None = None) -> None:
             "keep_warm": True,
             "keep_warm_expression": "rate(4 minutes)",
             "environment_variables": production_environment_variables,
-            "aws_environment_variables": {
-                "DATABASE_URL": db_secret_arn,
-                "SECRET_KEY": django_secret_arn,
-            },
+            "aws_environment_variables": aws_environment_variables,
             "apigateway_settings": {
                 "throttle_burst_limit": 100,
                 "throttle_rate_limit": 50,
@@ -359,10 +357,7 @@ def configure_zappa_settings(output_path: Path | None = None) -> None:
             "keep_warm": True,
             "keep_warm_expression": "rate(10 minutes)",
             "environment_variables": staging_environment_variables,
-            "aws_environment_variables": {
-                "DATABASE_URL": db_secret_arn,
-                "SECRET_KEY": django_secret_arn,
-            },
+            "aws_environment_variables": aws_environment_variables,
             "apigateway_settings": {
                 "throttle_burst_limit": 75,
                 "throttle_rate_limit": 40,

--- a/backend/scripts/configure_zappa.py
+++ b/backend/scripts/configure_zappa.py
@@ -12,6 +12,14 @@ from pathlib import Path
 DEV_STAGE_NAMES = {"dev"}
 PROD_STAGE_NAMES = {"prod"}
 STAGING_STAGE_NAMES = {"staging"}
+RUNTIME_ENVIRONMENT_VARIABLES = {
+    "USE_S3": "true",
+    "IS_LAMBDA": "true",
+    "USE_GEODJANGO": "true",
+    "GDAL_DATA": "/opt/share/gdal",
+    "PROJ_LIB": "/opt/share/proj",
+    "LD_LIBRARY_PATH": "/opt/lib:/opt/lib64",
+}
 
 
 def get_env_or_default(key: str, default: str = "") -> str:
@@ -200,14 +208,6 @@ def configure_zappa_settings(output_path: Path | None = None) -> None:
         dev_docker_image = "public.ecr.aws/lambda/python:3.13"
         production_docker_image = "public.ecr.aws/lambda/python:3.13"
 
-    runtime_environment_variables = {
-        "USE_S3": "true",
-        "IS_LAMBDA": "true",
-        "USE_GEODJANGO": "true",
-        "GDAL_DATA": "/opt/share/gdal",
-        "PROJ_LIB": "/opt/share/proj",
-        "LD_LIBRARY_PATH": "/opt/lib:/opt/lib64",
-    }
     aws_environment_variables = with_location_place_index(
         {
             "DATABASE_URL": db_secret_arn,
@@ -217,7 +217,7 @@ def configure_zappa_settings(output_path: Path | None = None) -> None:
     )
     dev_environment_variables = with_stage_cloudfront_domain(
         {
-            **runtime_environment_variables,
+            **RUNTIME_ENVIRONMENT_VARIABLES,
             "ENVIRONMENT": "dev",
             "DEBUG": "true",
             "DATABASE_NAME": dev_db_name,
@@ -229,7 +229,7 @@ def configure_zappa_settings(output_path: Path | None = None) -> None:
     )
     production_environment_variables = with_stage_cloudfront_domain(
         {
-            **runtime_environment_variables,
+            **RUNTIME_ENVIRONMENT_VARIABLES,
             "ENVIRONMENT": "production",
             "DEBUG": "false",
             "DATABASE_NAME": production_db_name,
@@ -338,7 +338,7 @@ def configure_zappa_settings(output_path: Path | None = None) -> None:
 
         staging_environment_variables = with_stage_cloudfront_domain(
             {
-                **runtime_environment_variables,
+                **RUNTIME_ENVIRONMENT_VARIABLES,
                 "ENVIRONMENT": "staging",
                 "DEBUG": "false",
                 "DATABASE_NAME": staging_db_name,

--- a/backend/scripts/tests/test_configure_zappa.py
+++ b/backend/scripts/tests/test_configure_zappa.py
@@ -98,11 +98,11 @@ class TestProvidedSecretARNs:
 class TestLocationConfiguration:
     """Tests for the AWS Location place index in generated settings."""
 
-    def test_place_index_name_is_added_to_each_stage_environment(
+    def test_place_index_name_is_added_to_each_stage_aws_environment(
         self,
         tmp_path: Path,
     ) -> None:
-        """Every generated Lambda stage must receive the configured place index."""
+        """Every stage must expose the place index through Lambda configuration."""
         settings = _generate_settings(
             tmp_path,
             {
@@ -113,10 +113,14 @@ class TestLocationConfiguration:
 
         for stage in ("dev", "staging", "prod"):
             assert (
-                settings[stage]["environment_variables"][
+                settings[stage]["aws_environment_variables"][
                     "AWS_LOCATION_PLACE_INDEX_NAME"
                 ]
                 == "landandbay-geocoding-index"
+            )
+            assert (
+                "AWS_LOCATION_PLACE_INDEX_NAME"
+                not in settings[stage]["environment_variables"]
             )
 
     def test_unconfigured_place_index_is_omitted_outside_ci(
@@ -127,10 +131,14 @@ class TestLocationConfiguration:
         settings = _generate_settings(tmp_path)
 
         for stage in ("dev", "prod"):
-            assert (
-                "AWS_LOCATION_PLACE_INDEX_NAME"
-                not in settings[stage]["environment_variables"]
-            )
+            for environment_key in (
+                "environment_variables",
+                "aws_environment_variables",
+            ):
+                assert (
+                    "AWS_LOCATION_PLACE_INDEX_NAME"
+                    not in settings[stage][environment_key]
+                )
 
     def test_runtime_variables_are_materialized_in_each_stage(
         self,

--- a/backend/scripts/tests/test_configure_zappa.py
+++ b/backend/scripts/tests/test_configure_zappa.py
@@ -98,20 +98,26 @@ class TestProvidedSecretARNs:
 class TestLocationConfiguration:
     """Tests for the AWS Location place index in generated settings."""
 
-    def test_place_index_name_is_added_to_lambda_environment(
+    def test_place_index_name_is_added_to_each_stage_environment(
         self,
         tmp_path: Path,
     ) -> None:
-        """The configured place index must be available to the geocoding service."""
+        """Every generated Lambda stage must receive the configured place index."""
         settings = _generate_settings(
             tmp_path,
-            {"AWS_LOCATION_PLACE_INDEX_NAME": "landandbay-geocoding-index"},
+            {
+                "AWS_LOCATION_PLACE_INDEX_NAME": "landandbay-geocoding-index",
+                "ENABLE_STAGING": "true",
+            },
         )
 
-        assert (
-            settings["base"]["environment_variables"]["AWS_LOCATION_PLACE_INDEX_NAME"]
-            == "landandbay-geocoding-index"
-        )
+        for stage in ("dev", "staging", "prod"):
+            assert (
+                settings[stage]["environment_variables"][
+                    "AWS_LOCATION_PLACE_INDEX_NAME"
+                ]
+                == "landandbay-geocoding-index"
+            )
 
     def test_unconfigured_place_index_is_omitted_outside_ci(
         self,
@@ -120,10 +126,25 @@ class TestLocationConfiguration:
         """Local settings should not contain a misleading empty index name."""
         settings = _generate_settings(tmp_path)
 
-        assert (
-            "AWS_LOCATION_PLACE_INDEX_NAME"
-            not in settings["base"]["environment_variables"]
-        )
+        for stage in ("dev", "prod"):
+            assert (
+                "AWS_LOCATION_PLACE_INDEX_NAME"
+                not in settings[stage]["environment_variables"]
+            )
+
+    def test_runtime_variables_are_materialized_in_each_stage(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """Stage maps must retain runtime variables when overriding base settings."""
+        settings = _generate_settings(tmp_path, {"ENABLE_STAGING": "true"})
+
+        for stage in ("dev", "staging", "prod"):
+            stage_environment = settings[stage]["environment_variables"]
+            assert stage_environment["IS_LAMBDA"] == "true"
+            assert stage_environment["USE_GEODJANGO"] == "true"
+            assert stage_environment["GDAL_DATA"] == "/opt/share/gdal"
+            assert stage_environment["PROJ_LIB"] == "/opt/share/proj"
 
 
 class TestAssetConfiguration:

--- a/backend/scripts/tests/test_configure_zappa.py
+++ b/backend/scripts/tests/test_configure_zappa.py
@@ -7,7 +7,10 @@ from unittest.mock import patch
 
 import pytest
 
-from scripts.configure_zappa import configure_zappa_settings
+from scripts.configure_zappa import (
+    RUNTIME_ENVIRONMENT_VARIABLES,
+    configure_zappa_settings,
+)
 
 
 def _generate_settings(
@@ -149,10 +152,7 @@ class TestLocationConfiguration:
 
         for stage in ("dev", "staging", "prod"):
             stage_environment = settings[stage]["environment_variables"]
-            assert stage_environment["IS_LAMBDA"] == "true"
-            assert stage_environment["USE_GEODJANGO"] == "true"
-            assert stage_environment["GDAL_DATA"] == "/opt/share/gdal"
-            assert stage_environment["PROJ_LIB"] == "/opt/share/proj"
+            assert RUNTIME_ENVIRONMENT_VARIABLES.items() <= stage_environment.items()
 
 
 class TestAssetConfiguration:

--- a/backend/zappa_settings.json.example
+++ b/backend/zappa_settings.json.example
@@ -17,15 +17,6 @@
     "timeout_seconds": 30,
     "slim_handler": false,
     "use_precompiled_packages": false,
-    "environment_variables": {
-      "USE_S3": "true",
-      "IS_LAMBDA": "true",
-      "USE_GEODJANGO": "true",
-      "GDAL_DATA": "/opt/share/gdal",
-      "PROJ_LIB": "/opt/share/proj",
-      "LD_LIBRARY_PATH": "/opt/lib:/opt/lib64",
-      "AWS_LOCATION_PLACE_INDEX_NAME": "coalition-geocoding-index"
-    },
     "exclude": [
       "*.gz",
       "*.rar",
@@ -64,6 +55,12 @@
     "memory_size": 512,
     "keep_warm": false,
     "environment_variables": {
+      "USE_S3": "true",
+      "IS_LAMBDA": "true",
+      "USE_GEODJANGO": "true",
+      "GDAL_DATA": "/opt/share/gdal",
+      "PROJ_LIB": "/opt/share/proj",
+      "LD_LIBRARY_PATH": "/opt/lib:/opt/lib64",
       "ENVIRONMENT": "dev",
       "DEBUG": "true",
       "DATABASE_NAME": "coalition_dev",
@@ -71,7 +68,8 @@
     },
     "aws_environment_variables": {
       "DATABASE_URL": "arn:aws:secretsmanager:us-east-1:XXXXXXXXXXXX:secret:coalition/database-url-XXXXXX",
-      "SECRET_KEY": "arn:aws:secretsmanager:us-east-1:XXXXXXXXXXXX:secret:coalition/secret-key-XXXXXX"
+      "SECRET_KEY": "arn:aws:secretsmanager:us-east-1:XXXXXXXXXXXX:secret:coalition/secret-key-XXXXXX",
+      "AWS_LOCATION_PLACE_INDEX_NAME": "coalition-geocoding-index"
     },
     "apigateway_settings": {
       "throttle_burst_limit": 50,
@@ -86,6 +84,12 @@
     "keep_warm": true,
     "keep_warm_expression": "rate(10 minutes)",
     "environment_variables": {
+      "USE_S3": "true",
+      "IS_LAMBDA": "true",
+      "USE_GEODJANGO": "true",
+      "GDAL_DATA": "/opt/share/gdal",
+      "PROJ_LIB": "/opt/share/proj",
+      "LD_LIBRARY_PATH": "/opt/lib:/opt/lib64",
       "ENVIRONMENT": "staging",
       "DEBUG": "false",
       "DATABASE_NAME": "coalition_staging",
@@ -93,7 +97,8 @@
     },
     "aws_environment_variables": {
       "DATABASE_URL": "arn:aws:secretsmanager:us-east-1:XXXXXXXXXXXX:secret:coalition/database-url-XXXXXX",
-      "SECRET_KEY": "arn:aws:secretsmanager:us-east-1:XXXXXXXXXXXX:secret:coalition/secret-key-XXXXXX"
+      "SECRET_KEY": "arn:aws:secretsmanager:us-east-1:XXXXXXXXXXXX:secret:coalition/secret-key-XXXXXX",
+      "AWS_LOCATION_PLACE_INDEX_NAME": "coalition-geocoding-index"
     },
     "apigateway_settings": {
       "throttle_burst_limit": 75,
@@ -108,6 +113,12 @@
     "keep_warm": true,
     "keep_warm_expression": "rate(4 minutes)",
     "environment_variables": {
+      "USE_S3": "true",
+      "IS_LAMBDA": "true",
+      "USE_GEODJANGO": "true",
+      "GDAL_DATA": "/opt/share/gdal",
+      "PROJ_LIB": "/opt/share/proj",
+      "LD_LIBRARY_PATH": "/opt/lib:/opt/lib64",
       "ENVIRONMENT": "production",
       "DEBUG": "false",
       "DATABASE_NAME": "coalition_production",
@@ -115,7 +126,8 @@
     },
     "aws_environment_variables": {
       "DATABASE_URL": "arn:aws:secretsmanager:us-east-1:XXXXXXXXXXXX:secret:coalition/database-url-XXXXXX",
-      "SECRET_KEY": "arn:aws:secretsmanager:us-east-1:XXXXXXXXXXXX:secret:coalition/secret-key-XXXXXX"
+      "SECRET_KEY": "arn:aws:secretsmanager:us-east-1:XXXXXXXXXXXX:secret:coalition/secret-key-XXXXXX",
+      "AWS_LOCATION_PLACE_INDEX_NAME": "coalition-geocoding-index"
     },
     "apigateway_settings": {
       "throttle_burst_limit": 100,

--- a/backend/zappa_settings.json.template
+++ b/backend/zappa_settings.json.template
@@ -15,17 +15,6 @@
         "slim_handler": false,
         "use_precompiled_packages": false,
         
-        "environment_variables": {
-            "USE_S3": "true",
-            "AWS_STORAGE_BUCKET_NAME": "YOUR-ASSETS-BUCKET",
-            "IS_LAMBDA": "true",
-            "USE_GEODJANGO": "true",
-            "GDAL_DATA": "/opt/share/gdal",
-            "PROJ_LIB": "/opt/share/proj",
-            "LD_LIBRARY_PATH": "/opt/lib:/opt/lib64",
-            "AWS_LOCATION_PLACE_INDEX_NAME": "YOUR-PLACE-INDEX-NAME"
-        },
-        
         "exclude": [
             "*.gz", "*.rar", "*.zip", "*.tar",
             ".git/*", "tests/*", "*.pyc", "local/*",
@@ -54,6 +43,12 @@
         "keep_warm": false,
         
         "environment_variables": {
+            "USE_S3": "true",
+            "IS_LAMBDA": "true",
+            "USE_GEODJANGO": "true",
+            "GDAL_DATA": "/opt/share/gdal",
+            "PROJ_LIB": "/opt/share/proj",
+            "LD_LIBRARY_PATH": "/opt/lib:/opt/lib64",
             "ENVIRONMENT": "dev",
             "DEBUG": "true",
             "DATABASE_NAME": "YOUR-DEV-DB-NAME",
@@ -62,7 +57,8 @@
         
         "aws_environment_variables": {
             "DATABASE_URL": "arn:aws:secretsmanager:REGION:ACCOUNT:secret:YOUR-DB-SECRET",
-            "SECRET_KEY": "arn:aws:secretsmanager:REGION:ACCOUNT:secret:YOUR-DJANGO-SECRET"
+            "SECRET_KEY": "arn:aws:secretsmanager:REGION:ACCOUNT:secret:YOUR-DJANGO-SECRET",
+            "AWS_LOCATION_PLACE_INDEX_NAME": "YOUR-PLACE-INDEX-NAME"
         },
         
         "apigateway_settings": {
@@ -80,6 +76,12 @@
         "keep_warm_expression": "rate(10 minutes)",
         
         "environment_variables": {
+            "USE_S3": "true",
+            "IS_LAMBDA": "true",
+            "USE_GEODJANGO": "true",
+            "GDAL_DATA": "/opt/share/gdal",
+            "PROJ_LIB": "/opt/share/proj",
+            "LD_LIBRARY_PATH": "/opt/lib:/opt/lib64",
             "ENVIRONMENT": "staging",
             "DEBUG": "false",
             "DATABASE_NAME": "YOUR-STAGING-DB-NAME",
@@ -88,7 +90,8 @@
         
         "aws_environment_variables": {
             "DATABASE_URL": "arn:aws:secretsmanager:REGION:ACCOUNT:secret:YOUR-DB-SECRET",
-            "SECRET_KEY": "arn:aws:secretsmanager:REGION:ACCOUNT:secret:YOUR-DJANGO-SECRET"
+            "SECRET_KEY": "arn:aws:secretsmanager:REGION:ACCOUNT:secret:YOUR-DJANGO-SECRET",
+            "AWS_LOCATION_PLACE_INDEX_NAME": "YOUR-PLACE-INDEX-NAME"
         },
         
         "apigateway_settings": {
@@ -106,6 +109,12 @@
         "keep_warm_expression": "rate(4 minutes)",
         
         "environment_variables": {
+            "USE_S3": "true",
+            "IS_LAMBDA": "true",
+            "USE_GEODJANGO": "true",
+            "GDAL_DATA": "/opt/share/gdal",
+            "PROJ_LIB": "/opt/share/proj",
+            "LD_LIBRARY_PATH": "/opt/lib:/opt/lib64",
             "ENVIRONMENT": "production",
             "DEBUG": "false",
             "DATABASE_NAME": "YOUR-PRODUCTION-DB-NAME",
@@ -114,7 +123,8 @@
         
         "aws_environment_variables": {
             "DATABASE_URL": "arn:aws:secretsmanager:REGION:ACCOUNT:secret:YOUR-DB-SECRET",
-            "SECRET_KEY": "arn:aws:secretsmanager:REGION:ACCOUNT:secret:YOUR-DJANGO-SECRET"
+            "SECRET_KEY": "arn:aws:secretsmanager:REGION:ACCOUNT:secret:YOUR-DJANGO-SECRET",
+            "AWS_LOCATION_PLACE_INDEX_NAME": "YOUR-PLACE-INDEX-NAME"
         },
         
         "apigateway_settings": {


### PR DESCRIPTION
## Summary

- Materialize shared runtime environment variables, including `AWS_LOCATION_PLACE_INDEX_NAME`, in every generated Zappa stage.
- Fail explicitly when the address-suggestion provider is unavailable instead of returning a misleading empty result.
- Verify the deployed Lambda retains the place-index setting and expose Lambda tail output in normal workflow logs.

## Root cause

Zappa stage-level `environment_variables` replaced the base map, so production Lambda never received `AWS_LOCATION_PLACE_INDEX_NAME` even though deployment configuration validation succeeded. The address service then converted the missing-provider condition into `{"suggestions": [], "count": 0}`, making an operational failure look like a valid no-match response.

## Impact

Address autocomplete can reach the configured AWS Location index after deployment. Future configuration/provider failures surface as errors, and deployments fail immediately if Lambda drops the required setting.

## Validation

- `poetry run pytest coalition/stakeholders/tests/test_services.py -q --no-cov` — 38 passed
- `poetry run pytest coalition/api/tests/test_address.py scripts/tests/test_configure_zappa.py -q --no-cov` — 54 passed
- `poetry run ruff check coalition/stakeholders/services.py coalition/stakeholders/tests/test_services.py scripts/configure_zappa.py scripts/tests/test_configure_zappa.py`
- `.github/scripts/test_deployment_workflows.sh`
- `git diff --check origin/main...`

The full local backend run completed with 532 passing tests and 175 failures caused by the pre-existing Django Ninja router reattachment issue (`Router@'/address/' has already been attached to API`).