### PR TITLE
docs: reflect completed serverless migration and measured AWS costs

### DIFF
--- a/.github/workflows/dev_cost_control.yml
+++ b/.github/workflows/dev_cost_control.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       vpc_endpoints:
-        description: "VPC Endpoints (disable to save ~$22/mo when not developing)"
+        description: "Dev VPC endpoints (disable both when not developing)"
         required: true
         type: choice
         options:

--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ flowchart TD
 
 ## 🧭 Architecture
 
-Production is fully serverless: API Gateway fronts a containerized Lambda running Django, and Vercel serves the Next.js frontend, proxying `/api/*` to the API. ECS Fargate remains only for one-off TIGER geodata import tasks.
+Production is fully serverless: API Gateway fronts a containerized Lambda running Django, and Vercel serves the Next.js frontend, proxying `/api/*` to the API. The repository contains ECS-based TIGER import scaffolding, but no current Terraform environment provisions it.
 
 ```mermaid
 %%{init: {'theme':'basic'}}%%
@@ -123,7 +123,6 @@ flowchart LR
         S3[S3 + CloudFront<br/>static & media]
         SES[SES<br/>transactional email]
         Location[AWS Location Service<br/>geocoding]
-        ECS[ECS Fargate<br/>TIGER geodata imports]
     end
 
     User --> Next
@@ -133,7 +132,6 @@ flowchart LR
     Lambda --> S3
     Lambda --> SES
     Lambda --> Location
-    ECS --> RDS
 ```
 
 There are no always-on servers: no ALB, no ECS service, and no NAT gateway — the Lambda reaches AWS services through VPC endpoints. Terraform is split into `shared` (VPC, RDS, bastion), `prod`, and `dev` environments, with GitHub Actions authenticating via OIDC.

--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ flowchart LR
 
 Transactional email is currently blocked in Lambda. [PR #312](https://github.com/lhadjchikh/coalition-builder/pull/312) replaces the unreachable SMTP path with the SES API over a VPC endpoint.
 
-There are no always-on servers: no ALB, no ECS service, and no NAT gateway — the Lambda reaches AWS services through VPC endpoints. Terraform is split into `shared` (VPC, RDS, bastion), `prod`, and `dev` environments, with GitHub Actions authenticating via OIDC.
+There are no always-on application servers: no ALB, no ECS application service, and no NAT gateway. RDS and the EC2 bastion remain always-on resources, while Lambda reaches AWS services through VPC endpoints. Terraform is split into `shared` (VPC, RDS, bastion), `prod`, and `dev` environments, with GitHub Actions authenticating via OIDC.
 
 For the resource inventory, IAM policies, and cost breakdown, see the [AWS Serverless Deployment guide](https://lhadjchikh.github.io/coalition-builder/deployment/aws/).
 

--- a/README.md
+++ b/README.md
@@ -153,9 +153,6 @@ For the resource inventory, IAM policies, and cost breakdown, see the [AWS Serve
 - [📡 API Reference](https://lhadjchikh.github.io/coalition-builder/api/) - Auto-generated API documentation
 - [🚀 Deployment Guide](https://lhadjchikh.github.io/coalition-builder/deployment/) - Serverless deployment overview
 - [☁️ AWS Deployment](https://lhadjchikh.github.io/coalition-builder/deployment/aws/) - Full infrastructure walkthrough
-- [λ Lambda Deployment](https://lhadjchikh.github.io/coalition-builder/LAMBDA_DEPLOYMENT/) - Django on Lambda
-- [▲ Vercel Deployment](https://lhadjchikh.github.io/coalition-builder/VERCEL_DEPLOYMENT/) - Next.js on Vercel
-- [🧰 Serverless Setup](https://lhadjchikh.github.io/coalition-builder/serverless-setup/) - Configure your own AWS resources
 
 ## 🚀 Quick Start
 

--- a/README.md
+++ b/README.md
@@ -183,7 +183,7 @@ docker compose exec api python scripts/create_test_data.py
 
 ## 🚢 Deployment
 
-Infrastructure is provisioned with Terraform; both applications deploy through GitHub Actions. Pushes to `main` deploy production, and pushes to `development` deploy the dev environment.
+Infrastructure is provisioned with Terraform, and both applications deploy through GitHub Actions. Backend changes pushed to `main` or `development` trigger the corresponding Lambda deployment; frontend changes on those branches independently trigger the corresponding Vercel deployment.
 
 - [Deployment overview](https://lhadjchikh.github.io/coalition-builder/deployment/) - which pieces go where
 - [AWS Serverless Deployment](https://lhadjchikh.github.io/coalition-builder/deployment/aws/) - resources, IAM, and costs

--- a/README.md
+++ b/README.md
@@ -4,7 +4,9 @@
 [![Full Stack Tests](https://github.com/lhadjchikh/coalition-builder/actions/workflows/test_fullstack.yml/badge.svg)](https://github.com/lhadjchikh/coalition-builder/actions/workflows/test_fullstack.yml)
 [![Code Coverage](https://codecov.io/gh/lhadjchikh/coalition-builder/branch/main/graph/badge.svg?token=VGUU4R6NR3)](https://codecov.io/gh/lhadjchikh/coalition-builder)
 
-> **⚠️ Pre-Alpha Software:** This project is in pre-alpha and undergoing rapid development with a major serverless migration in progress ([PR #222](https://github.com/lhadjchikh/coalition-builder/pull/222)). No official releases yet. Expect frequent updates and architectural changes.
+> **⚠️ Pre-Alpha Software:** This project is in pre-alpha and undergoing rapid development. No official releases yet. Expect frequent updates and architectural changes.
+>
+> The migration from ECS Fargate to a serverless architecture ([PR #222](https://github.com/lhadjchikh/coalition-builder/pull/222)) is **complete**. Production runs Django on AWS Lambda and Next.js on Vercel; the ECS-based deployment is deprecated.
 
 A comprehensive platform for organizing and managing policy advocacy campaigns, bringing together stakeholders, legislators, and advocates to drive meaningful policy change.
 
@@ -24,8 +26,10 @@ A comprehensive platform for organizing and managing policy advocacy campaigns, 
   - [Core Functionality](#core-functionality)
   - [Endorsement System](#endorsement-system)
 - [Technology Stack](#️-technology-stack)
+- [Architecture](#-architecture)
 - [Documentation](#-documentation)
 - [Quick Start](#-quick-start)
+- [Deployment](#-deployment)
 - [Contributing](#-contributing)
 - [License](#-license)
 - [Support](#-support)
@@ -80,7 +84,7 @@ flowchart TD
 - **Content Management** - Easy-to-use Django admin interface
 - **API Integration** - RESTful API for custom integrations
 - **SEO Optimized** - Server-side rendering with Next.js
-- **Production Ready** - Secure AWS deployment with Terraform
+- **Serverless Deployment** - Django on AWS Lambda and Next.js on Vercel, provisioned with Terraform
 
 ### Endorsement System
 
@@ -93,9 +97,48 @@ flowchart TD
 
 ## 🏗️ Technology Stack
 
-- **Backend**: Django 5.2 + PostgreSQL + PostGIS
-- **Frontend**: Next.js 15 + React 19 + TypeScript (Server-Side Rendered)
-- **Infrastructure**: AWS + Terraform
+- **Backend**: Django 5.2 + Django Ninja on Python 3.13, running on AWS Lambda (packaged with Zappa as a container image)
+- **Frontend**: Next.js 16 + React 19 + TypeScript (server-side rendered), deployed to Vercel
+- **Database**: RDS PostgreSQL 16 with PostGIS, reached through private VPC subnets
+- **Infrastructure**: Terraform-managed AWS (API Gateway, Lambda, RDS, S3, CloudFront, Secrets Manager, SES, AWS Location Service)
+- **Local development**: Docker Compose (Django + Next.js + PostGIS)
+
+## 🧭 Architecture
+
+Production is fully serverless: API Gateway fronts a containerized Lambda running Django, and Vercel serves the Next.js frontend, proxying `/api/*` to the API. ECS Fargate remains only for one-off TIGER geodata import tasks.
+
+```mermaid
+%%{init: {'theme':'basic'}}%%
+flowchart LR
+    User[🌐 Visitors]
+
+    subgraph Vercel["▲ Vercel"]
+        Next[Next.js SSR Frontend]
+    end
+
+    subgraph AWS["☁️ AWS"]
+        APIGW[API Gateway]
+        Lambda[λ Django on Lambda<br/>Zappa container image]
+        RDS[(RDS PostgreSQL + PostGIS)]
+        S3[S3 + CloudFront<br/>static & media]
+        SES[SES<br/>transactional email]
+        Location[AWS Location Service<br/>geocoding]
+        ECS[ECS Fargate<br/>TIGER geodata imports]
+    end
+
+    User --> Next
+    Next -->|/api/*| APIGW
+    APIGW --> Lambda
+    Lambda --> RDS
+    Lambda --> S3
+    Lambda --> SES
+    Lambda --> Location
+    ECS --> RDS
+```
+
+There are no always-on servers: no ALB, no ECS service, and no NAT gateway — the Lambda reaches AWS services through VPC endpoints. Terraform is split into `shared` (VPC, RDS, bastion), `prod`, and `dev` environments, with GitHub Actions authenticating via OIDC.
+
+For the resource inventory, IAM policies, and cost breakdown, see the [AWS Serverless Deployment guide](https://lhadjchikh.github.io/coalition-builder/deployment/aws/).
 
 ## 📚 Documentation
 
@@ -107,9 +150,15 @@ flowchart TD
 - [🔧 Configuration](https://lhadjchikh.github.io/coalition-builder/configuration/) - Environment variables and settings
 - [💻 Development Guide](https://lhadjchikh.github.io/coalition-builder/development/) - Development workflow
 - [📡 API Reference](https://lhadjchikh.github.io/coalition-builder/api/) - Auto-generated API documentation
-- [🚀 Deployment Guide](https://lhadjchikh.github.io/coalition-builder/deployment/) - Production deployment options
+- [🚀 Deployment Guide](https://lhadjchikh.github.io/coalition-builder/deployment/) - Serverless deployment overview
+- [☁️ AWS Deployment](https://lhadjchikh.github.io/coalition-builder/deployment/aws/) - Full infrastructure walkthrough
+- [λ Lambda Deployment](https://lhadjchikh.github.io/coalition-builder/LAMBDA_DEPLOYMENT/) - Django on Lambda
+- [▲ Vercel Deployment](https://lhadjchikh.github.io/coalition-builder/VERCEL_DEPLOYMENT/) - Next.js on Vercel
+- [🧰 Serverless Setup](https://lhadjchikh.github.io/coalition-builder/serverless-setup/) - Configure your own AWS resources
 
 ## 🚀 Quick Start
+
+Local development runs the full stack in Docker — the serverless architecture applies to deployed environments only.
 
 ```bash
 # Clone the repository
@@ -117,7 +166,7 @@ git clone https://github.com/lhadjchikh/coalition-builder.git
 cd coalition-builder
 
 # Start with Docker (recommended)
-# For production/CI
+# For production-style builds / CI
 docker compose up -d
 
 # For local development with live code reload
@@ -127,11 +176,18 @@ docker compose -f docker-compose.yml -f docker-compose.dev.yml up -d
 docker compose exec api python scripts/create_test_data.py
 
 # Access the application
-# Frontend: http://localhost:3000 (SSR)
-# Frontend SPA: http://localhost:8000 (Django serves React)
+# Frontend: http://localhost:3000 (Next.js SSR)
 # API: http://localhost:8000/api/
 # Admin: http://localhost:8000/admin/
 ```
+
+## 🚢 Deployment
+
+Infrastructure is provisioned with Terraform; both applications deploy through GitHub Actions. Pushes to `main` deploy production, and pushes to `development` deploy the dev environment.
+
+- [Deployment overview](https://lhadjchikh.github.io/coalition-builder/deployment/) - which pieces go where
+- [AWS Serverless Deployment](https://lhadjchikh.github.io/coalition-builder/deployment/aws/) - resources, IAM, and costs
+- [terraform/README.md](terraform/README.md) - multi-account bootstrap, OIDC, and module reference
 
 ## 🤝 Contributing
 

--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ flowchart LR
         Lambda[λ Django on Lambda<br/>Zappa container image]
         RDS[(RDS PostgreSQL + PostGIS)]
         S3[S3 + CloudFront<br/>static & media]
-        SES[SES<br/>transactional email]
+        SES[SES API<br/>pending PR #312]
         Location[AWS Location Service<br/>geocoding]
     end
 
@@ -130,9 +130,11 @@ flowchart LR
     APIGW --> Lambda
     Lambda --> RDS
     Lambda --> S3
-    Lambda --> SES
+    Lambda -.->|pending #312| SES
     Lambda --> Location
 ```
+
+Transactional email is currently blocked in Lambda. [PR #312](https://github.com/lhadjchikh/coalition-builder/pull/312) replaces the unreachable SMTP path with the SES API over a VPC endpoint.
 
 There are no always-on servers: no ALB, no ECS service, and no NAT gateway — the Lambda reaches AWS services through VPC endpoints. Terraform is split into `shared` (VPC, RDS, bastion), `prod`, and `dev` environments, with GitHub Actions authenticating via OIDC.
 

--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ flowchart LR
 
 [PR #312](https://github.com/lhadjchikh/coalition-builder/pull/312) replaced the unreachable Lambda SMTP path with the SES API over a private VPC endpoint and execution-role authentication.
 
-There are no always-on application servers: no ALB, no ECS application service, and no NAT gateway. RDS and the EC2 bastion remain always-on resources, while Lambda reaches AWS services through VPC endpoints. Terraform is split into `shared` (VPC, RDS, bastion), `prod`, and `dev` environments, with GitHub Actions authenticating via OIDC.
+There are no always-on application servers: no ALB, no ECS application service, and no NAT gateway. RDS and the EC2 bastion remain always-on resources, while Lambda reaches AWS services through VPC endpoints. Terraform provisions a database VPC in `shared` plus separate application VPCs in `prod` and `dev`; the application VPCs are peered to `shared` for database access. GitHub Actions authenticates via OIDC.
 
 For the resource inventory, IAM policies, and cost breakdown, see the [AWS Serverless Deployment guide](https://lhadjchikh.github.io/coalition-builder/deployment/aws/).
 

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -12,9 +12,6 @@ CORS_ALLOWED_ORIGINS=http://localhost:3000,http://127.0.0.1:3000
 # CSRF settings (for production)
 CSRF_TRUSTED_ORIGINS=https://yourdomain.org,https://www.yourdomain.org
 
-# Cache settings
-CACHE_URL=redis://localhost:6379/1
-
 # AWS settings (for production)
 AWS_REGION=us-east-1
 AWS_ACCESS_KEY_ID=your-aws-access-key

--- a/docker-compose.override.yml.example
+++ b/docker-compose.override.yml.example
@@ -12,7 +12,6 @@ services:
       - DEBUG=True
       - SECRET_KEY=dev_secret_key_for_local_development
       - DATABASE_URL=postgis://coalition_app:app_password@db:5432/coalition
-      - CACHE_URL=redis://redis:6379/1
       - ALLOWED_HOSTS=localhost,127.0.0.1,api,nginx,app
       - CORS_ALLOWED_ORIGINS=http://localhost:3000,http://127.0.0.1:3000
 

--- a/docs/LAMBDA_DEPLOYMENT.md
+++ b/docs/LAMBDA_DEPLOYMENT.md
@@ -1,5 +1,7 @@
 # Lambda Deployment Configuration
 
+> **Historical reference — do not use these setup instructions.** They predate the OIDC-authenticated, container-image deployment and still describe static keys, ECS inputs, and an unprovisioned staging environment. Use [Deployment Workflows](deployment/workflows.md) and [AWS Serverless Deployment](deployment/aws.md).
+
 ## GitHub Environment Variables
 
 The Lambda deployment workflows use GitHub environment variables for configuration. These should be set up for each environment (dev, staging, production).

--- a/docs/VERCEL_DEPLOYMENT.md
+++ b/docs/VERCEL_DEPLOYMENT.md
@@ -1,5 +1,7 @@
 # Vercel Deployment Configuration
 
+> **Historical reference.** The current workflow deploys production from `main`, development from `development`, and previews from pull requests; there is no `staging` branch deployment. Use [Deployment Workflows](deployment/workflows.md) as the operational runbook.
+
 ## Initial Setup
 
 ### 1. Create Vercel Account and Project

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -2,9 +2,7 @@
 
 ## Overview
 
-Coalition Builder uses a **serverless architecture** for cost-effective, scalable deployment. The application is split between AWS Lambda (Django backend) and Vercel (Next.js frontend).
-
-**Cost Savings**: ~46% reduction from legacy ECS deployment ($39/month vs $73/month)
+Coalition Builder uses a **serverless architecture** for cost-effective, scalable deployment. The application is split between AWS Lambda (Django backend) and Vercel (Next.js frontend). For the resource-by-resource cost breakdown, see [AWS Serverless Deployment](deployment/aws.md#cost-analysis).
 
 ## Quick Start
 
@@ -13,37 +11,43 @@ Coalition Builder uses a **serverless architecture** for cost-effective, scalabl
 - AWS CLI configured with deployment permissions
 - GitHub repository with Actions enabled
 - Domain name with DNS access (optional)
-- Terraform 1.0+ for infrastructure
+- Terraform 1.12+ for infrastructure
 
 ### 2. Deploy Infrastructure
 
+Terraform is organized into per-account environments. Deploy `shared` first — it creates the VPC and RDS instance that `prod` and `dev` read via remote state.
+
 ```bash
-cd terraform
-terraform init
-terraform apply -target=module.dynamodb
-terraform apply -target=module.zappa
-terraform apply -target=module.geodata_import
+cd terraform/environments/shared
+terraform init -backend-config=backend.hcl
+terraform apply
+
+cd ../prod
+terraform init -backend-config=backend.hcl
+terraform apply
 ```
 
-### 3. Configure GitHub Secrets
+See [Multi-Account AWS Setup](deployment/multi-account-aws.md) for the bootstrap that must run before the first `terraform init`.
 
-Set these in your GitHub repository settings:
+### 3. Configure GitHub Secrets and Variables
+
+Deployment workflows authenticate to AWS with OIDC role assumption, so no long-lived AWS access keys are needed.
 
 **Secrets:**
 
-- `AWS_ACCESS_KEY_ID`
-- `AWS_SECRET_ACCESS_KEY`
-- `VERCEL_TOKEN`
-- `VERCEL_ORG_ID`
-- `VERCEL_PROJECT_ID`
+- `DATABASE_SECRET_ARN`, `DJANGO_SECRET_ARN` - Secrets Manager ARNs the Lambda role must be able to read
+- `VERCEL_TOKEN`, `VERCEL_ORG_ID`, `VERCEL_PROJECT_ID`
 
-**Environment Variables** (per environment):
+**Variables** (per GitHub Environment):
 
-- `DOMAIN_NAME` (optional)
-- `CERTIFICATE_ARN` (optional)
-- `PRODUCTION_API_URL`
-- `STAGING_API_URL`
-- `DEVELOPMENT_API_URL`
+- `AWS_ACCOUNT_ID` - determines the `github-actions-<env>` role to assume
+- `ZAPPA_S3_BUCKET`, `ZAPPA_ROLE_NAME` - from Terraform outputs
+- `AWS_STORAGE_BUCKET_NAME`, `CLOUDFRONT_DOMAIN`
+- `AWS_LOCATION_PLACE_INDEX_NAME`
+- `VPC_SUBNET_IDS`, `VPC_SECURITY_GROUP_IDS`
+- `PRODUCTION_API_URL` / `DEVELOPMENT_API_URL`, `PRODUCTION_SITE_URL` / `DEVELOPMENT_SITE_URL`
+
+See [GitHub Environment Setup](deployment/github-environment-setup.md) for the full list.
 
 ### 4. Deploy Applications
 
@@ -57,33 +61,29 @@ gh workflow run deploy_frontend.yml --ref main -f environment=prod
 
 ## Architecture
 
-### Current: Serverless Architecture
+```text
+Internet
+    ├── Vercel (Next.js Frontend) ──/api/*──┐
+    └── CloudFront CDN (static & media)     │
+                                            ▼
+                                    API Gateway → Lambda (Django via Zappa)
+                                                     ├── RDS PostgreSQL + PostGIS
+                                                     ├── S3 (static & media)
+                                                     ├── SES (transactional email)
+                                                     └── AWS Location Service (geocoding)
 
-```
-Internet → CloudFront CDN
-    ├── Vercel (Next.js Frontend)
-    └── API Gateway → Lambda (Django)
-         ├── RDS PostgreSQL
-         └── DynamoDB (Rate Limiting)
-
-ECS Fargate (TIGER Imports Only)
+ECS Fargate (TIGER geodata imports only)
 ```
 
 **Components:**
 
 - **Frontend**: Next.js on Vercel Edge Network
-- **Backend**: Django on AWS Lambda (via Zappa)
+- **Backend**: Django on AWS Lambda (via Zappa, as a container image)
 - **Database**: RDS PostgreSQL with PostGIS
-- **Rate Limiting**: DynamoDB (replaces Redis)
+- **Rate Limiting**: PostgreSQL-backed Django cache — see [Rate Limiting](rate-limiting.md)
 - **Geographic Data**: Imported via ECS Fargate tasks
 
-### Legacy: ECS Architecture (Deprecated)
-
-The previous ECS-based deployment is still documented for reference but deprecated:
-
-- Higher costs ($73/month vs $39/month)
-- More complex infrastructure management
-- Less scalable
+The ALB, ECS application service, and NAT gateway from the pre-2025 deployment have been removed. The Lambda reaches AWS services through VPC endpoints rather than a NAT gateway. See [AWS Serverless Deployment](deployment/aws.md) for the full resource inventory.
 
 ## Deployment Options
 
@@ -107,19 +107,14 @@ cd frontend
 vercel --prod
 ```
 
-### Staging Deployment
-
-**Automatic:**
-
-- Push to `staging` branch
-- Deploys to staging environment with keep-warm enabled
-
 ### Development Deployment
 
 **Automatic:**
 
-- Push to feature branches creates preview deployments
-- Pull requests get preview URLs
+- Push to `development` triggers a `dev` Lambda deployment and a Vercel deployment
+- Pull requests touching `frontend/` get Vercel preview URLs
+
+> **No staging environment.** `zappa_settings.json.template` defines a `staging` stage, but no Terraform environment or deployment workflow targets it. Only `dev` and `prod` are provisioned and wired to CI.
 
 **Local Development:**
 
@@ -198,7 +193,7 @@ Environment variables are set via GitHub Actions:
 
 2. **Configure DNS:**
 
-   ```
+   ```text
    Type: CNAME
    Name: @
    Value: cname.vercel-dns.com
@@ -263,21 +258,11 @@ Environment variables are set via GitHub Actions:
 
 ## Cost Management
 
-### Monthly Costs (Approximate)
-
-**Serverless Architecture:**
-
-- Lambda: ~$5
-- API Gateway: ~$4
-- Vercel: $0-20 (depending on traffic)
-- RDS: ~$15
-- DynamoDB: ~$1
-- Other (S3, CloudWatch): ~$5
-- **Total: ~$39/month**
+The per-service cost breakdown lives in [AWS Serverless Deployment](deployment/aws.md#cost-analysis) so there is a single set of figures to keep current.
 
 **Cost Optimization:**
 
-- DynamoDB pay-per-request billing
+- Lambda and API Gateway bill per request, with no idle cost
 - Lambda keep-warm only for production
 - Vercel free tier for development
 - ECS only for occasional TIGER imports
@@ -308,14 +293,6 @@ Environment variables are set via GitHub Actions:
 - See [Vercel deployment guide](VERCEL_DEPLOYMENT.md)
 - Review CloudWatch logs for errors
 
-## Migration from Legacy
+## Migration from ECS
 
-If migrating from the ECS deployment:
-
-1. **Backup Data:** Export database and user uploads
-2. **Test Serverless:** Deploy to staging first
-3. **Update DNS:** Point to new endpoints
-4. **Monitor:** Check performance and error rates
-5. **Cleanup:** Remove ECS resources after verification
-
-See the migration plan in `backend/local/SERVERLESS_MIGRATION_PLAN.md` for detailed steps.
+The migration from ECS Fargate to this serverless architecture is complete — see [PR #222](https://github.com/lhadjchikh/coalition-builder/pull/222). The ALB, ECS application service, and NAT gateway have been decommissioned, and no ECS deployment path remains for the application. ECS Fargate is still used for TIGER geodata imports; see [Geodata Import](deployment/geodata-import.md).

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -189,6 +189,7 @@ Environment variables are set via GitHub Actions:
    ```
 
 2. **Set GitHub Variables:**
+
    - `DOMAIN_NAME`: `api.yourdomain.com`
    - `CERTIFICATE_ARN`: ACM certificate ARN
 
@@ -197,6 +198,7 @@ Environment variables are set via GitHub Actions:
 ### Vercel (Frontend)
 
 1. **Add Domain in Vercel Dashboard:**
+
    - Project Settings → Domains
    - Add `yourdomain.com`
 
@@ -281,11 +283,13 @@ The per-service cost breakdown lives in [AWS Serverless Deployment](deployment/a
 ### Common Issues
 
 1. **Lambda Cold Starts**
+
    - Enable keep-warm for production
    - Increase memory allocation
    - Use provisioned concurrency if needed
 
 2. **Database Connection Errors**
+
    - Check VPC configuration
    - Verify security groups
    - Check connection pool settings

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -72,7 +72,7 @@ Internet
                                                      ├── SES (transactional email)
                                                      └── AWS Location Service (geocoding)
 
-ECS Fargate (TIGER geodata imports only)
+TIGER geodata import scaffolding (not currently provisioned)
 ```
 
 **Components:**
@@ -81,7 +81,7 @@ ECS Fargate (TIGER geodata imports only)
 - **Backend**: Django on AWS Lambda (via Zappa, as a container image)
 - **Database**: RDS PostgreSQL with PostGIS
 - **Rate Limiting**: PostgreSQL-backed Django cache — see [Rate Limiting](rate-limiting.md)
-- **Geographic Data**: Imported via ECS Fargate tasks
+- **Geographic Data**: The repository includes an ECS import module and workflow, but no current environment provisions them
 
 The ALB, ECS application service, and NAT gateway from the pre-2025 deployment have been removed. The Lambda reaches AWS services through VPC endpoints rather than a NAT gateway. See [AWS Serverless Deployment](deployment/aws.md) for the full resource inventory.
 
@@ -295,4 +295,4 @@ The per-service cost breakdown lives in [AWS Serverless Deployment](deployment/a
 
 ## Migration from ECS
 
-The migration from ECS Fargate to this serverless architecture is complete — see [PR #222](https://github.com/lhadjchikh/coalition-builder/pull/222). The ALB, ECS application service, and NAT gateway have been decommissioned, and no ECS deployment path remains for the application. ECS Fargate is still used for TIGER geodata imports; see [Geodata Import](deployment/geodata-import.md).
+The migration from ECS Fargate to this serverless architecture is complete — see [PR #222](https://github.com/lhadjchikh/coalition-builder/pull/222). The ALB, ECS application service, and NAT gateway have been decommissioned, and no ECS deployment path remains for the application. ECS-based TIGER import scaffolding remains in the repository but is not provisioned in any current environment; see [Geodata Import](deployment/geodata-import.md).

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -100,9 +100,8 @@ The ALB, ECS application service, and NAT gateway from the pre-2025 deployment h
 
 **Automatic via GitHub Actions:**
 
-- Push to `main` branch triggers production deployment
-- Backend deploys to Lambda with production settings
-- Frontend deploys to Vercel with custom domain
+- Backend changes pushed to `main` deploy Lambda with production settings
+- Frontend changes pushed to `main` independently deploy Vercel with the production custom domain
 
 **Manual Deployment:**
 
@@ -120,7 +119,8 @@ vercel --prod
 
 **Automatic:**
 
-- Push to `development` triggers a `dev` Lambda deployment and a Vercel deployment
+- Backend changes pushed to `development` trigger the `dev` Lambda deployment
+- Frontend changes pushed to `development` independently trigger the development Vercel deployment
 - Pull requests touching `frontend/` get Vercel preview URLs
 
 > **No staging environment.** `zappa_settings.json.template` defines a `staging` stage, but no Terraform environment or deployment workflow targets it. Only `dev` and `prod` are provisioned and wired to CI.

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -15,7 +15,7 @@ Coalition Builder uses a **serverless architecture** for cost-effective, scalabl
 
 ### 2. Deploy Infrastructure
 
-Terraform is organized into per-account environments. Deploy `shared` first — it creates the VPC and RDS instance that `prod` and `dev` read via remote state.
+Terraform is organized into per-account environments. Deploy `shared` first — it creates the database VPC and RDS instance that `prod` and `dev` read via remote state before creating their own application VPCs.
 
 Complete the account bootstrap in [Multi-Account AWS Setup](deployment/multi-account-aws.md) and export the required `TF_VAR_*` inputs from [Configure GitHub Secrets and Variables](#3-configure-github-secrets-and-variables) before running Terraform manually. The backend setup script generates the gitignored `backend.hcl` in each environment directory.
 
@@ -117,7 +117,7 @@ Transactional email uses the SES API over a private VPC endpoint and authenticat
 - **Rate Limiting**: PostgreSQL-backed Django cache — see [Rate Limiting](rate-limiting.md)
 - **Geographic Data**: The repository includes an ECS import module and workflow, but no current environment provisions them
 
-The ALB, ECS application service, and NAT gateway from the pre-2025 deployment have been removed. The Lambda reaches AWS services through VPC endpoints rather than a NAT gateway. See [AWS Serverless Deployment](deployment/aws.md) for the full resource inventory.
+The ALB, ECS application service, and NAT gateway from the previous ECS deployment have been removed. The Lambda reaches AWS services through VPC endpoints rather than a NAT gateway. See [AWS Serverless Deployment](deployment/aws.md) for the full resource inventory.
 
 ## Deployment Options
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -213,7 +213,6 @@ Environment variables are set via GitHub Actions:
    ```
 
 2. **Set GitHub Variables:**
-
    - `DOMAIN_NAME`: `api.yourdomain.com`
    - `CERTIFICATE_ARN`: ACM certificate ARN
 
@@ -222,7 +221,6 @@ Environment variables are set via GitHub Actions:
 ### Vercel (Frontend)
 
 1. **Add Domain in Vercel Dashboard:**
-
    - Project Settings → Domains
    - Add `yourdomain.com`
 
@@ -307,13 +305,11 @@ The per-service cost breakdown lives in [AWS Serverless Deployment](deployment/a
 ### Common Issues
 
 1. **Lambda Cold Starts**
-
    - Enable keep-warm for production
    - Increase memory allocation
    - Use provisioned concurrency if needed
 
 2. **Database Connection Errors**
-
    - Check VPC configuration
    - Verify security groups
    - Check connection pool settings

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -31,32 +31,51 @@ See [Multi-Account AWS Setup](deployment/multi-account-aws.md) for the bootstrap
 
 ### 3. Configure GitHub Secrets and Variables
 
-Deployment workflows authenticate to AWS with OIDC role assumption, so no long-lived AWS access keys are needed.
+The Lambda, Lambda-management, and Terraform deployment workflows authenticate to AWS with OIDC role assumption. The legacy geodata-import workflow and Terraform integration-test job still use `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY`; do not remove those credentials until those workflows are migrated or retired.
 
-**GitHub Environment secrets** (`prod` and `dev`, used by the Lambda and Terraform jobs):
+**Lambda GitHub Environment secrets** (`prod` and `dev`):
 
 - `DATABASE_SECRET_ARN`, `DJANGO_SECRET_ARN` - Secrets Manager ARNs the Lambda role must be able to read
 
-**GitHub Environment variables** (`prod` and `dev`):
+**Terraform GitHub Environment secrets:**
+
+| Environment   | Required secrets                                                | Optional secret                                             |
+| ------------- | --------------------------------------------------------------- | ----------------------------------------------------------- |
+| `shared`      | `DB_USERNAME`, `DB_PASSWORD`, `APP_DB_USERNAME`                 | `TF_VAR_BASTION_PUBLIC_KEY` when `CREATE_NEW_KEY_PAIR=true` |
+| `prod`, `dev` | `APP_DB_USERNAME`, `APP_DB_PASSWORD`, `SHARED_PEERING_ROLE_ARN` | `SITE_PASSWORD`                                             |
+
+**Common Terraform GitHub Environment variables:**
+
+- `AWS_ACCOUNT_ID`, `TF_VAR_PREFIX`, and `REPO_FULL_NAME`
+- `TF_VAR_ALERT_EMAIL` for every environment
+- `SHARED_ACCOUNT_ID` for `prod` and `dev`
+- `TF_VAR_DOMAIN_NAME`, `BASTION_KEY_NAME`, `CREATE_NEW_KEY_PAIR`, `ALLOWED_BASTION_CIDRS`, and `ALLOWED_LAMBDA_CIDRS` for `shared`
+- `SES_FROM_EMAIL`, `SES_NOTIFICATION_EMAIL`, and `TF_VAR_DOMAIN_NAME` for `prod`
+
+The reusable Terraform workflow also accepts optional variables such as `TF_VAR_API_GATEWAY_ID` and additional bastion settings. Treat `.github/workflows/deploy_terraform_environment.yml` and `.github/scripts/validate_terraform_environment_variables.sh` as the authoritative input list.
+
+**Lambda GitHub Environment variables** (`prod` and `dev`):
 
 - `AWS_ACCOUNT_ID` - determines the `github-actions-<env>` role to assume
 - `ZAPPA_S3_BUCKET`, `ZAPPA_ROLE_NAME` - from Terraform outputs
 - `AWS_STORAGE_BUCKET_NAME`, `CLOUDFRONT_DOMAIN`
 - `AWS_LOCATION_PLACE_INDEX_NAME`
 - `VPC_SUBNET_IDS`, `VPC_SECURITY_GROUP_IDS`
+- The selected environment's `PRODUCTION_API_URL` or `DEVELOPMENT_API_URL`
 - `SITE_URL`, `DEFAULT_FROM_EMAIL` - required for production email links and the SES sender
-- `ADMIN_NOTIFICATION_EMAILS`, `SES_CONFIGURATION_SET` - notification recipients and SES event tracking
+- `ADMIN_NOTIFICATION_EMAILS`, `SES_CONFIGURATION_SET` - optional notification recipients and SES event tracking
 
 **Repository secrets** (used by the frontend job, which does not select a GitHub Environment):
 
 - `VERCEL_TOKEN`, `VERCEL_ORG_ID`, `VERCEL_PROJECT_ID`
 
-**Repository variables** (used by the frontend job):
+**Repository variables** (used by the frontend job, which has no GitHub Environment scope):
 
 - `PRODUCTION_API_URL` / `DEVELOPMENT_API_URL`, `PRODUCTION_SITE_URL` / `DEVELOPMENT_SITE_URL`
-- `AWS_STORAGE_BUCKET_NAME`, `CLOUDFRONT_DOMAIN`
+- `AWS_STORAGE_BUCKET_NAME`, `CLOUDFRONT_DOMAIN`, `PRODUCTION_DOMAIN`
+- `GOOGLE_ANALYTICS_ID` - optional analytics identifier
 
-Some names intentionally exist at both repository and environment scope because the frontend and Lambda workflows read different scopes. See [Deployment Workflows](deployment/workflows.md) for workflow behavior.
+`PRODUCTION_API_URL` and `DEVELOPMENT_API_URL` intentionally exist at both repository and environment scope because the frontend and Lambda workflows read different scopes. See [Deployment Workflows](deployment/workflows.md) for workflow behavior.
 
 ### 4. Deploy Applications
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -33,21 +33,28 @@ See [Multi-Account AWS Setup](deployment/multi-account-aws.md) for the bootstrap
 
 Deployment workflows authenticate to AWS with OIDC role assumption, so no long-lived AWS access keys are needed.
 
-**Secrets:**
+**GitHub Environment secrets** (`prod` and `dev`, used by the Lambda and Terraform jobs):
 
 - `DATABASE_SECRET_ARN`, `DJANGO_SECRET_ARN` - Secrets Manager ARNs the Lambda role must be able to read
-- `VERCEL_TOKEN`, `VERCEL_ORG_ID`, `VERCEL_PROJECT_ID`
 
-**Variables** (per GitHub Environment):
+**GitHub Environment variables** (`prod` and `dev`):
 
 - `AWS_ACCOUNT_ID` - determines the `github-actions-<env>` role to assume
 - `ZAPPA_S3_BUCKET`, `ZAPPA_ROLE_NAME` - from Terraform outputs
 - `AWS_STORAGE_BUCKET_NAME`, `CLOUDFRONT_DOMAIN`
 - `AWS_LOCATION_PLACE_INDEX_NAME`
 - `VPC_SUBNET_IDS`, `VPC_SECURITY_GROUP_IDS`
-- `PRODUCTION_API_URL` / `DEVELOPMENT_API_URL`, `PRODUCTION_SITE_URL` / `DEVELOPMENT_SITE_URL`
 
-See [GitHub Environment Setup](deployment/github-environment-setup.md) for the full list.
+**Repository secrets** (used by the frontend job, which does not select a GitHub Environment):
+
+- `VERCEL_TOKEN`, `VERCEL_ORG_ID`, `VERCEL_PROJECT_ID`
+
+**Repository variables** (used by the frontend job):
+
+- `PRODUCTION_API_URL` / `DEVELOPMENT_API_URL`, `PRODUCTION_SITE_URL` / `DEVELOPMENT_SITE_URL`
+- `AWS_STORAGE_BUCKET_NAME`, `CLOUDFRONT_DOMAIN`
+
+Some names intentionally exist at both repository and environment scope because the frontend and Lambda workflows read different scopes. See [Deployment Workflows](deployment/workflows.md) for workflow behavior.
 
 ### 4. Deploy Applications
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -17,17 +17,21 @@ Coalition Builder uses a **serverless architecture** for cost-effective, scalabl
 
 Terraform is organized into per-account environments. Deploy `shared` first — it creates the VPC and RDS instance that `prod` and `dev` read via remote state.
 
+Complete the account bootstrap in [Multi-Account AWS Setup](deployment/multi-account-aws.md) and export the required `TF_VAR_*` inputs from [Configure GitHub Secrets and Variables](#3-configure-github-secrets-and-variables) before running Terraform manually. The backend setup script generates the gitignored `backend.hcl` in each environment directory.
+
 ```bash
 cd terraform/environments/shared
+../../scripts/setup_remote_state.sh shared
 terraform init -backend-config=backend.hcl
-terraform apply
+terraform plan -out=tfplan
+terraform apply tfplan
 
 cd ../prod
+../../scripts/setup_remote_state.sh prod
 terraform init -backend-config=backend.hcl
-terraform apply
+terraform plan -out=tfplan
+terraform apply tfplan
 ```
-
-See [Multi-Account AWS Setup](deployment/multi-account-aws.md) for the bootstrap that must run before the first `terraform init`.
 
 ### 3. Configure GitHub Secrets and Variables
 
@@ -127,9 +131,8 @@ The ALB, ECS application service, and NAT gateway from the pre-2025 deployment h
 **Manual Deployment:**
 
 ```bash
-# Lambda backend
-cd backend
-poetry run zappa deploy prod
+# Lambda backend (preferred; builds and passes the immutable image URI)
+gh workflow run deploy_lambda.yml --ref main -f environment=prod
 
 # Vercel frontend
 cd frontend
@@ -323,8 +326,8 @@ The per-service cost breakdown lives in [AWS Serverless Deployment](deployment/a
 ### Getting Help
 
 - Check [GitHub Actions workflows](deployment/workflows.md)
-- View [Lambda deployment guide](LAMBDA_DEPLOYMENT.md)
-- See [Vercel deployment guide](VERCEL_DEPLOYMENT.md)
+- View [Deployment Workflows](deployment/workflows.md)
+- See [AWS Serverless Deployment](deployment/aws.md)
 - Review CloudWatch logs for errors
 
 ## Migration from ECS

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -69,11 +69,13 @@ Internet
                                     API Gateway → Lambda (Django via Zappa)
                                                      ├── RDS PostgreSQL + PostGIS
                                                      ├── S3 (static & media)
-                                                     ├── SES (transactional email)
+                                                     ├╌ SES API (blocked pending PR #312)
                                                      └── AWS Location Service (geocoding)
 
 TIGER geodata import scaffolding (not currently provisioned)
 ```
+
+Transactional email is not operational on the current Lambda deployment. [PR #312](https://github.com/lhadjchikh/coalition-builder/pull/312) replaces the unreachable SMTP path with the SES API over a VPC endpoint.
 
 **Components:**
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -300,7 +300,7 @@ The per-service cost breakdown lives in [AWS Serverless Deployment](deployment/a
 - Lambda and API Gateway bill per request, with no idle cost
 - Lambda keep-warm only for production
 - Vercel free tier for development
-- ECS only for occasional TIGER imports
+- Retained TIGER import scaffolding incurs no ECS cost because no current environment provisions it
 
 ## Troubleshooting
 

--- a/docs/deployment/aws.md
+++ b/docs/deployment/aws.md
@@ -21,12 +21,6 @@ flowchart TB
         lambda --> ses[SES]
         lambda --> geo[AWS Location Service]
 
-        subgraph ecs_occasional["ECS (Occasional Use)"]
-            ecs_task[Fargate Task<br/>TIGER Data Import]
-        end
-
-        ecs_task --> rds
-
         subgraph security["Security & Monitoring"]
             secrets[Secrets Manager]
             cloudwatch[CloudWatch Logs]
@@ -85,12 +79,9 @@ There is no DynamoDB table. Rate limiting uses the PostgreSQL-backed Django cach
 - **Media Uploads**: `coalition-builder-media`
 - **Zappa Deployments**: `coalition-builder-zappa-deployments`
 
-#### ECS Fargate (TIGER Imports)
+#### TIGER Geodata Imports
 
-- **Cluster**: `coalition-builder-geodata-import`
-- **Task Definition**: 2 vCPU, 4GB RAM
-- **Usage**: Triggered manually for shapefile imports
-- **Frequency**: Monthly or as needed
+The repository contains an ECS Fargate module and manual workflow for TIGER imports, but no current Terraform environment instantiates the module and no import cluster is provisioned. Treat the workflow as unavailable until an environment explicitly wires it in.
 
 #### CloudWatch
 
@@ -213,7 +204,7 @@ To find out what is behind a surprising service total, re-run with `--group-by T
 
 - **Lambda**: Pay-per-invocation (no idle costs)
 - **API Gateway**: Pay-per-request
-- **ECS**: Only runs for TIGER imports
+- **ECS**: No current environment provisions the retained TIGER import scaffolding
 - **Single-AZ VPC endpoints**: Half the cost of endpoints in every private subnet
 
 ## Security

--- a/docs/deployment/aws.md
+++ b/docs/deployment/aws.md
@@ -182,7 +182,7 @@ for p in landandbay-prod landandbay-shared landandbay-dev; do
     --time-period Start=2026-07-01,End=2026-08-01 \
     --granularity MONTHLY --metrics UnblendedCost \
     --group-by Type=DIMENSION,Key=SERVICE \
-    --query 'ResultsByTime[].Groups[?Metrics.UnblendedCost.Amount>`0.01`].[Keys[0],Metrics.UnblendedCost.Amount]' \
+    --query 'ResultsByTime[].Groups[?to_number(Metrics.UnblendedCost.Amount) > `0.01`].[Keys[0],Metrics.UnblendedCost.Amount]' \
     --output text
 done
 ```

--- a/docs/deployment/aws.md
+++ b/docs/deployment/aws.md
@@ -176,27 +176,50 @@ Measured from Cost Explorer (unblended) for July 2026, across all three accounts
 |            | _dev subtotal_          | _$24.68_   |
 | **Total**  |                         | **$82.04** |
 
+Displayed rows are curated from Cost Explorer service and usage-type results rather than copied service labels. Account subtotals include sub-cent lines omitted by the `$0.01` display threshold and are rounded independently, so the visible shared and dev rows are each one cent below their subtotal.
+
 Vercel is billed separately and is not included above.
 
 #### Refreshing these figures
 
-These are measured numbers, not estimates — regenerate them rather than adjusting them by hand. Costs are per-account, so all three profiles must be summed.
+These are measured numbers, not estimates — regenerate them rather than adjusting them by hand. Costs are per-account, so query all three account profiles. Cost Explorer has a single `us-east-1` API endpoint, so keep the explicit region even if the profiles default elsewhere.
 
 ```bash
-aws sso login --profile landandbay-prod
+profiles=(your-prod-profile your-shared-profile your-dev-profile)
 
-for p in landandbay-prod landandbay-shared landandbay-dev; do
-  echo "=== $p ==="
-  aws ce get-cost-and-usage --profile "$p" \
+for profile in "${profiles[@]}"; do
+  aws sso login --profile "$profile"
+
+  echo "=== $profile: service totals ==="
+  aws ce get-cost-and-usage --profile "$profile" --region us-east-1 \
     --time-period Start=2026-07-01,End=2026-08-01 \
     --granularity MONTHLY --metrics UnblendedCost \
     --group-by Type=DIMENSION,Key=SERVICE \
     --query 'ResultsByTime[].Groups[?to_number(Metrics.UnblendedCost.Amount) > `0.01`].[Keys[0],Metrics.UnblendedCost.Amount]' \
     --output text
+
+  echo "=== $profile: EC2 usage types ==="
+  aws ce get-cost-and-usage --profile "$profile" --region us-east-1 \
+    --time-period Start=2026-07-01,End=2026-08-01 \
+    --granularity MONTHLY --metrics UnblendedCost \
+    --filter '{"Dimensions":{"Key":"SERVICE","Values":["EC2 - Other"]}}' \
+    --group-by Type=DIMENSION,Key=USAGE_TYPE \
+    --query 'ResultsByTime[].Groups[?to_number(Metrics.UnblendedCost.Amount) > `0.01`].[Keys[0],Metrics.UnblendedCost.Amount]' \
+    --output text
 done
 ```
 
-To find out what is behind a surprising service total, re-run with `--group-by Type=DIMENSION,Key=USAGE_TYPE` and a `--filter` on that service. That is how the VPC line above resolved to `USE1-VpcEndpoint-Hours`.
+Translate raw Cost Explorer rows into the display labels consistently:
+
+| Display label           | Source                                                        |
+| ----------------------- | ------------------------------------------------------------- |
+| VPC interface endpoints | `EC2 - Other` usage type ending in `VpcEndpoint-Hours`        |
+| Public IPv4 addresses   | `EC2 - Other` public-IPv4 usage types                         |
+| EC2 (bastion)           | EC2 instance usage (`BoxUsage:*`)                             |
+| EC2 - Other             | Remaining EC2 - Other total after the named usage types above |
+| Other services          | Cost Explorer service name, shortened only for readability    |
+
+For any surprising service total, repeat the second query with that exact service in the filter. Preserve the mapping table when adding or renaming a curated row.
 
 ### What actually drives the bill
 

--- a/docs/deployment/aws.md
+++ b/docs/deployment/aws.md
@@ -71,7 +71,7 @@ The SES edge is not operational in the current Lambda deployment. [PR #312](http
 - **Purpose**: Let the Lambda in private subnets reach AWS services without a NAT gateway
 - **Cost**: $0.01/hour each — see [Cost Analysis](#cost-analysis), where these are the largest line item
 
-There is no DynamoDB table. Rate limiting uses the PostgreSQL-backed Django cache; see [Rate Limiting](../rate-limiting.md).
+There is no application rate-limiting DynamoDB table. The bootstrap still creates DynamoDB tables for Terraform state locking. Application rate limiting uses the PostgreSQL-backed Django cache; see [Rate Limiting](../rate-limiting.md).
 
 ### Supporting Resources
 
@@ -194,7 +194,7 @@ To find out what is behind a surprising service total, re-run with `--group-by T
 - **VPC interface endpoints are the single largest cost — $44.64/month across prod and dev**, more than RDS. Each account runs three interface endpoints (Secrets Manager, CloudWatch Logs, and AWS Location `geo.places`) at $0.01/hour each. They are pinned to a single AZ (`enable_single_az_endpoints`), which already halves what multi-AZ would cost.
 - **Compute is effectively free.** Lambda does not appear as a line item at all, and API Gateway costs $0.03/month at current traffic. The serverless migration did deliver on compute cost.
 - **The dev account costs nearly as much as prod ($24.68 vs $31.92)** despite serving no traffic, because VPC endpoint hours accrue whether or not the Lambda is invoked.
-- **No DynamoDB line exists**, which confirms rate limiting runs on the PostgreSQL-backed Django cache rather than DynamoDB.
+- **No DynamoDB cost line appears above the reporting threshold.** The application code and settings — not the billing data — establish that rate limiting uses the PostgreSQL-backed Django cache. Terraform state-lock tables still exist.
 
 ### Cost reduction opportunities
 

--- a/docs/deployment/aws.md
+++ b/docs/deployment/aws.md
@@ -237,7 +237,9 @@ To find out what is behind a surprising service total, re-run with `--group-by T
       "Effect": "Allow",
       "Action": [
         "geo:SearchPlaceIndexForText",
-        "geo:SearchPlaceIndexForSuggestions"
+        "geo:SearchPlaceIndexForPosition",
+        "geo:SearchPlaceIndexForSuggestions",
+        "geo:GetPlace"
       ],
       "Resource": "arn:aws:geo:*:*:place-index/coalition-*"
     }

--- a/docs/deployment/aws.md
+++ b/docs/deployment/aws.md
@@ -16,9 +16,10 @@ flowchart TB
         cloudfront --> apigateway[API Gateway]
         apigateway --> lambda[Lambda Function<br/>Django via Zappa]
 
-        lambda --> rds[(RDS PostgreSQL<br/>with PostGIS)]
-        lambda --> dynamodb[(DynamoDB<br/>Rate Limiting)]
+        lambda --> rds[(RDS PostgreSQL<br/>with PostGIS<br/>+ rate-limit cache)]
         lambda --> s3_static[S3 Static Assets]
+        lambda --> ses[SES]
+        lambda --> geo[AWS Location Service]
 
         subgraph ecs_occasional["ECS (Occasional Use)"]
             ecs_task[Fargate Task<br/>TIGER Data Import]
@@ -67,12 +68,14 @@ flowchart TB
 - **Multi-AZ**: Disabled (cost optimization)
 - **Backup**: 7-day retention
 
-#### DynamoDB
+#### VPC Interface Endpoints
 
-- **Billing**: Pay-per-request
-- **Tables**: `coalition-builder-rate-limits`
-- **TTL**: Enabled for automatic cleanup
-- **Global Secondary Index**: None (simple key structure)
+- **Endpoints**: Secrets Manager, CloudWatch Logs, AWS Location (`geo.places`)
+- **Placement**: Single AZ (`enable_single_az_endpoints`) to halve hourly cost
+- **Purpose**: Let the Lambda in private subnets reach AWS services without a NAT gateway
+- **Cost**: $0.01/hour each — see [Cost Analysis](#cost-analysis), where these are the largest line item
+
+There is no DynamoDB table. Rate limiting uses the PostgreSQL-backed Django cache; see [Rate Limiting](../rate-limiting.md).
 
 ### Supporting Resources
 
@@ -92,7 +95,7 @@ flowchart TB
 #### CloudWatch
 
 - **Log Groups**: `/aws/lambda/{function-name}`
-- **Metrics**: API Gateway, Lambda, DynamoDB
+- **Metrics**: API Gateway, Lambda, RDS
 - **Retention**: 7 days (cost optimization)
 
 #### Secrets Manager
@@ -105,25 +108,34 @@ flowchart TB
 
 ### Terraform Modules
 
-```bash
+```text
 terraform/
-├── modules/
-│   ├── dynamodb/          # Rate limiting tables
-│   ├── zappa/             # S3 + IAM for Lambda
-│   ├── geodata-import/    # ECS for TIGER imports
-│   └── database/          # RDS PostgreSQL (existing)
+├── environments/
+│   ├── shared/            # VPC, RDS, bastion
+│   ├── prod/              # Lambda, API Gateway, S3, SES
+│   └── dev/               # Lambda, S3
+└── modules/
+    ├── networking/        # VPC, subnets, VPC endpoints
+    ├── database/          # RDS PostgreSQL with PostGIS
+    ├── zappa/             # S3 + IAM for Lambda deployment
+    ├── lambda-ecr/        # ECR repositories for Lambda images
+    ├── aws-location/      # AWS Location Service place index
+    ├── geodata-import/    # ECS for TIGER imports
+    └── ...                # See terraform/README.md for the full list
 ```
 
 ### Deployment Commands
 
+Deploy `shared` first — `prod` and `dev` read its VPC and RDS outputs via remote state.
+
 ```bash
-# Deploy core infrastructure
-cd terraform
-terraform init
-terraform apply -target=module.database
-terraform apply -target=module.dynamodb
-terraform apply -target=module.zappa
-terraform apply -target=module.geodata_import
+cd terraform/environments/shared
+terraform init -backend-config=backend.hcl
+terraform apply
+
+cd ../prod
+terraform init -backend-config=backend.hcl
+terraform apply
 
 # Deploy applications via GitHub Actions
 gh workflow run deploy_lambda.yml --ref main -f environment=prod
@@ -131,27 +143,78 @@ gh workflow run deploy_lambda.yml --ref main -f environment=prod
 
 ## Cost Analysis
 
-### Monthly Costs (Approximate)
+This is the authoritative cost reference; other pages link here rather than restating figures.
 
-| Service       | Legacy ECS | Serverless      | Savings |
-| ------------- | ---------- | --------------- | ------- |
-| Compute       | ECS: $25   | Lambda: $5      | $20     |
-| Load Balancer | ALB: $16   | API Gateway: $4 | $12     |
-| Networking    | NAT: $32   | None: $0        | $32     |
-| Database      | RDS: $15   | RDS: $15        | $0      |
-| Storage       | S3: $5     | S3: $5          | $0      |
-| Other         | $5         | DynamoDB: $1    | $4      |
-| **Total**     | **$98**    | **$30**         | **$68** |
+### Actual Monthly Costs
 
-**Savings: 69% reduction**
+Measured from Cost Explorer (unblended) for July 2026, across all three accounts. Only lines above $0.01 are shown.
+
+| Account    | Service                 | Monthly    |
+| ---------- | ----------------------- | ---------- |
+| **prod**   | VPC interface endpoints | $22.32     |
+|            | WAF                     | $6.00      |
+|            | Secrets Manager         | $1.61      |
+|            | KMS                     | $1.00      |
+|            | Route 53                | $0.50      |
+|            | ECR                     | $0.46      |
+|            | API Gateway             | $0.03      |
+|            | _prod subtotal_         | _$31.92_   |
+| **shared** | RDS PostgreSQL          | $16.04     |
+|            | Public IPv4 addresses   | $3.72      |
+|            | EC2 (bastion)           | $3.12      |
+|            | KMS                     | $1.00      |
+|            | EC2 - Other             | $0.64      |
+|            | Route 53                | $0.51      |
+|            | Secrets Manager         | $0.40      |
+|            | _shared subtotal_       | _$25.44_   |
+| **dev**    | VPC interface endpoints | $22.32     |
+|            | Secrets Manager         | $1.20      |
+|            | KMS                     | $1.00      |
+|            | ECR                     | $0.15      |
+|            | _dev subtotal_          | _$24.68_   |
+| **Total**  |                         | **$82.04** |
+
+Vercel is billed separately and is not included above.
+
+#### Refreshing these figures
+
+These are measured numbers, not estimates — regenerate them rather than adjusting them by hand. Costs are per-account, so all three profiles must be summed.
+
+```bash
+aws sso login --profile landandbay-prod
+
+for p in landandbay-prod landandbay-shared landandbay-dev; do
+  echo "=== $p ==="
+  aws ce get-cost-and-usage --profile "$p" \
+    --time-period Start=2026-07-01,End=2026-08-01 \
+    --granularity MONTHLY --metrics UnblendedCost \
+    --group-by Type=DIMENSION,Key=SERVICE \
+    --query 'ResultsByTime[].Groups[?Metrics.UnblendedCost.Amount>`0.01`].[Keys[0],Metrics.UnblendedCost.Amount]' \
+    --output text
+done
+```
+
+To find out what is behind a surprising service total, re-run with `--group-by Type=DIMENSION,Key=USAGE_TYPE` and a `--filter` on that service. That is how the VPC line above resolved to `USE1-VpcEndpoint-Hours`.
+
+### What actually drives the bill
+
+- **VPC interface endpoints are the single largest cost — $44.64/month across prod and dev**, more than RDS. Each account runs three interface endpoints (Secrets Manager, CloudWatch Logs, and AWS Location `geo.places`) at $0.01/hour each. They are pinned to a single AZ (`enable_single_az_endpoints`), which already halves what multi-AZ would cost.
+- **Compute is effectively free.** Lambda does not appear as a line item at all, and API Gateway costs $0.03/month at current traffic. The serverless migration did deliver on compute cost.
+- **The dev account costs nearly as much as prod ($24.68 vs $31.92)** despite serving no traffic, because VPC endpoint hours accrue whether or not the Lambda is invoked.
+- **No DynamoDB line exists**, which confirms rate limiting runs on the PostgreSQL-backed Django cache rather than DynamoDB.
+
+### Cost reduction opportunities
+
+- Removing the three interface endpoints from the **dev** account would save ~$22/month. Dev would then need another route to Secrets Manager, CloudWatch Logs, and AWS Location.
+- The `geo.places` endpoint is only needed by code paths that geocode; dropping it where unused saves ~$7.44/month per account.
+- WAF ($6.00/month, prod only) is a fixed web-ACL charge.
 
 ### Cost Optimization Features
 
-- **DynamoDB**: Pay-per-request (no idle costs)
 - **Lambda**: Pay-per-invocation (no idle costs)
 - **API Gateway**: Pay-per-request
-- **ECS**: Only runs for TIGER imports (~$2/year)
-- **No NAT Gateway**: Lambda doesn't need VPC for most operations
+- **ECS**: Only runs for TIGER imports
+- **Single-AZ VPC endpoints**: Half the cost of endpoints in every private subnet
 
 ## Security
 
@@ -179,8 +242,11 @@ gh workflow run deploy_lambda.yml --ref main -f environment=prod
     },
     {
       "Effect": "Allow",
-      "Action": ["dynamodb:Query", "dynamodb:PutItem", "dynamodb:GetItem"],
-      "Resource": "arn:aws:dynamodb:*:*:table/coalition-builder-*"
+      "Action": [
+        "geo:SearchPlaceIndexForText",
+        "geo:SearchPlaceIndexForSuggestions"
+      ],
+      "Resource": "arn:aws:geo:*:*:place-index/coalition-*"
     }
   ]
 }
@@ -217,11 +283,11 @@ gh workflow run deploy_lambda.yml --ref main -f environment=prod
 - 4xx/5xx error rates
 - Cache hit rates
 
-#### DynamoDB Metrics
+#### RDS Metrics
 
-- Read/write capacity usage
-- Throttling events
-- Item count trends
+- Connection count (Lambda concurrency can exhaust the connection limit)
+- CPU and freeable memory
+- Storage growth, including the `django_cache` rate-limit table
 
 ### X-Ray Tracing
 
@@ -247,26 +313,21 @@ aws cloudwatch put-metric-alarm \
 
 ## Deployment Environments
 
+Only `dev` and `prod` are provisioned. `zappa_settings.json.template` also defines a `staging` stage, but no Terraform environment or deployment workflow targets it.
+
 ### Development
 
 - Lambda: 512MB memory, no keep-warm
 - API Gateway: Lower throttling limits
-- RDS: Shared with staging
-- DynamoDB: Shared table with environment prefix
-
-### Staging
-
-- Lambda: 512MB memory, 10-minute keep-warm
-- API Gateway: Production-like throttling
-- RDS: Shared with development
-- DynamoDB: Shared table with environment prefix
+- RDS: `coalition_dev` database on the shared account's RDS instance
+- Rate limiting: `django_cache` table in the dev database
 
 ### Production
 
 - Lambda: 1024MB memory, 4-minute keep-warm
 - API Gateway: Full throttling protection
-- RDS: Dedicated instance
-- DynamoDB: Dedicated table
+- RDS: `coalition` database on the shared account's RDS instance
+- Rate limiting: `django_cache` table in the production database
 - X-Ray: Enabled
 
 ## Backup & Disaster Recovery
@@ -283,11 +344,9 @@ aws cloudwatch put-metric-alarm \
 - Rollback via Zappa: `zappa rollback prod -n 1`
 - Code stored in S3 deployment bucket
 
-### DynamoDB
+### Rate-limit cache
 
-- Point-in-time recovery: Enabled
-- On-demand backups: Manual
-- Global tables: Not needed (single region)
+No separate backup is needed. Rate-limit counters live in the `django_cache` table inside the application database and are covered by RDS backups; losing them only resets in-flight rate-limit windows.
 
 ## Troubleshooting
 
@@ -358,7 +417,7 @@ aws logs filter-log-events \
 - Lambda functions
 - API Gateway
 - RDS primary
-- DynamoDB tables
+- VPC interface endpoints
 
 ### Vercel Edge Locations
 

--- a/docs/deployment/aws.md
+++ b/docs/deployment/aws.md
@@ -59,7 +59,7 @@ Lambda sends transactional email through the SES API over a private VPC endpoint
 #### RDS PostgreSQL
 
 - **Engine**: PostgreSQL 16 with PostGIS
-- **Instance**: db.t3.micro (dev) to db.t3.small (production)
+- **Instance**: One shared `db.t4g.micro` instance by default
 - **Storage**: 20GB GP3 with autoscaling
 - **Multi-AZ**: Disabled (cost optimization)
 - **Backup**: 7-day retention
@@ -70,8 +70,10 @@ Lambda sends transactional email through the SES API over a private VPC endpoint
 - **Development, when enabled**: Secrets Manager and AWS Location (`geo.places`)
 - **Placement**: Single AZ (`enable_single_az_endpoints`) to halve hourly cost
 - **Purpose**: Let the Lambda in private subnets reach AWS services without a NAT gateway
-- **CloudWatch Logs**: No interface endpoint is provisioned; Lambda delivers its own logs without one
+- **CloudWatch Logs**: The per-account environments provision no Logs interface endpoint; Lambda delivers its own logs without one. The retained root configuration still uses the networking module's default Logs endpoint.
 - **Cost**: $0.01/hour each — see [Cost Analysis](#cost-analysis). The July 2026 snapshot predates the Logs-to-SES endpoint swap in production and removal of the Logs endpoint in development.
+
+#### Rate Limiting and State Locking
 
 There is no application rate-limiting DynamoDB table. The bootstrap still creates DynamoDB tables for Terraform state locking. Application rate limiting uses the PostgreSQL-backed Django cache; see [Rate Limiting](../rate-limiting.md).
 
@@ -105,10 +107,11 @@ The repository contains an ECS Fargate module and manual workflow for TIGER impo
 
 ```text
 terraform/
+├── main.tf                  # Retained single-account root configuration
 ├── environments/
-│   ├── shared/            # VPC, RDS, bastion
-│   ├── prod/              # Lambda, API Gateway, S3, SES
-│   └── dev/               # Lambda, S3
+│   ├── shared/              # Database VPC, RDS, bastion
+│   ├── prod/                # Production application VPC and services
+│   └── dev/                 # Development application VPC and services
 └── modules/
     ├── networking/        # VPC, subnets, VPC endpoints
     ├── database/          # RDS PostgreSQL with PostGIS
@@ -248,6 +251,16 @@ To find out what is behind a surprising service total, re-run with `--group-by T
         "geo:GetPlace"
       ],
       "Resource": "arn:aws:geo:*:*:place-index/coalition-*"
+    },
+    {
+      "Effect": "Allow",
+      "Action": ["ses:SendEmail", "ses:SendRawEmail"],
+      "Resource": "*",
+      "Condition": {
+        "StringLike": {
+          "ses:FromAddress": ["*@example.org", "noreply@example.org"]
+        }
+      }
     }
   ]
 }
@@ -320,15 +333,15 @@ Only `dev` and `prod` are provisioned. `zappa_settings.json.template` also defin
 
 - Lambda: 512MB memory, no keep-warm
 - API Gateway: Lower throttling limits
-- RDS: `coalition_dev` database on the shared account's RDS instance
-- Rate limiting: `django_cache` table in the dev database
+- RDS: The Secrets Manager URL currently defaults to the shared instance's `coalition` database
+- Rate limiting: `django_cache` table in the selected application database
 
 ### Production
 
 - Lambda: 1024MB memory, 4-minute keep-warm
 - API Gateway: Full throttling protection
-- RDS: `coalition` database on the shared account's RDS instance
-- Rate limiting: `django_cache` table in the production database
+- RDS: The Secrets Manager URL defaults to the shared instance's `coalition` database
+- Rate limiting: `django_cache` table in the selected application database
 - X-Ray: Enabled
 
 ## Backup & Disaster Recovery

--- a/docs/deployment/aws.md
+++ b/docs/deployment/aws.md
@@ -18,7 +18,7 @@ flowchart TB
 
         lambda --> rds[(RDS PostgreSQL<br/>with PostGIS<br/>+ rate-limit cache)]
         lambda --> s3_static[S3 Static Assets]
-        lambda --> ses[SES]
+        lambda -.->|pending PR #312| ses[SES API]
         lambda --> geo[AWS Location Service]
 
         subgraph security["Security & Monitoring"]
@@ -34,6 +34,8 @@ flowchart TB
 
     vercel --> apigateway
 ```
+
+The SES edge is not operational in the current Lambda deployment. [PR #312](https://github.com/lhadjchikh/coalition-builder/pull/312) adds the SES API VPC endpoint, execution-role permissions, and application backend needed to enable it.
 
 ## AWS Resources
 

--- a/docs/deployment/aws.md
+++ b/docs/deployment/aws.md
@@ -121,16 +121,20 @@ terraform/
 
 ### Deployment Commands
 
-Deploy `shared` first — `prod` and `dev` read its VPC and RDS outputs via remote state.
+Deploy `shared` first — `prod` and `dev` read its VPC and RDS outputs via remote state. Complete the [multi-account bootstrap](multi-account-aws.md) and configure the required inputs before these commands. `setup_remote_state.sh` generates each environment's gitignored `backend.hcl`.
 
 ```bash
 cd terraform/environments/shared
+../../scripts/setup_remote_state.sh shared
 terraform init -backend-config=backend.hcl
-terraform apply
+terraform plan -out=tfplan
+terraform apply tfplan
 
 cd ../prod
+../../scripts/setup_remote_state.sh prod
 terraform init -backend-config=backend.hcl
-terraform apply
+terraform plan -out=tfplan
+terraform apply tfplan
 
 # Deploy applications via GitHub Actions
 gh workflow run deploy_lambda.yml --ref main -f environment=prod

--- a/docs/deployment/geodata-import.md
+++ b/docs/deployment/geodata-import.md
@@ -1,8 +1,10 @@
 # Geographic Data Import
 
+> **Unavailable in current environments.** The ECS module and manual workflow remain as scaffolding, but no `shared`, `prod`, or `dev` Terraform environment instantiates the import cluster or task definition. The commands below become usable only after an environment explicitly provisions and wires those resources.
+
 ## Overview
 
-The Coalition Builder uses TIGER/Line shapefiles from the U.S. Census Bureau for geographic boundaries. These imports are run as ECS Fargate tasks to handle the CPU and memory-intensive GDAL operations.
+The Coalition Builder uses TIGER/Line shapefiles from the U.S. Census Bureau for geographic boundaries. The retained design runs these imports as ECS Fargate tasks to handle the CPU- and memory-intensive GDAL operations.
 
 ## Architecture
 
@@ -19,7 +21,7 @@ ECS Fargate Task (4GB RAM, 2 vCPU)
 
 ### Automatic Import via GitHub Actions
 
-The easiest way to import geographic data is through the GitHub Actions workflow:
+After provisioning the retained ECS resources, the intended entry point is the GitHub Actions workflow:
 
 1. Go to Actions → Geographic Data Import
 2. Click "Run workflow"
@@ -27,7 +29,7 @@ The easiest way to import geographic data is through the GitHub Actions workflow
    - **Import type**: states, counties, places, or all
    - **States**: Comma-separated state codes or "all"
    - **Year**: TIGER data year (default: 2023)
-   - **Environment**: dev, staging, or production
+   - **Environment**: `dev` or `prod`
 
 ### Manual Import via ECS
 
@@ -170,10 +172,12 @@ WHERE NOT ST_IsValid(geometry);
 ### Import Fails
 
 1. **Out of Memory**
+
    - Increase ECS task memory
    - Import smaller batches of states
 
 2. **Network Timeout**
+
    - Census FTP may be slow
    - Retry or download files locally first
 

--- a/docs/deployment/geodata-import.md
+++ b/docs/deployment/geodata-import.md
@@ -172,12 +172,10 @@ WHERE NOT ST_IsValid(geometry);
 ### Import Fails
 
 1. **Out of Memory**
-
    - Increase ECS task memory
    - Import smaller batches of states
 
 2. **Network Timeout**
-
    - Census FTP may be slow
    - Retry or download files locally first
 

--- a/docs/deployment/github-environment-setup.md
+++ b/docs/deployment/github-environment-setup.md
@@ -95,7 +95,6 @@ For domain verification, ensure:
 On first deployment with SES:
 
 1. **Terraform will**:
-
    - Create all SES resources
    - Verify your domain automatically (if using Route53)
    - Grant the Lambda execution role SES send permission
@@ -111,13 +110,11 @@ On first deployment with SES:
 After deployment, verify the setup:
 
 1. **Check AWS Console**:
-
    - SES → Verified identities → Your domain should be verified
    - VPC → Endpoints → the production `email` interface endpoint should be available
    - SES → Account dashboard → production access should be enabled
 
 2. **Check Lambda and CloudWatch**:
-
    - Lambda configuration contains `DEFAULT_FROM_EMAIL`, `SITE_URL`, and the optional notification variables
    - Successful sends appear in SES metrics
    - Delivery failures increment the `EmailDeliveryFailures` metric and alarm

--- a/docs/deployment/multi-account-aws.md
+++ b/docs/deployment/multi-account-aws.md
@@ -404,7 +404,7 @@ Both authenticate via OIDC and select the target environment based on branch or 
 
 ### Dev Cost Control
 
-The **Dev Cost Control** workflow (`dev_cost_control.yml`) lets you toggle VPC endpoints in the dev environment on or off to save costs when not actively developing. VPC endpoints cost about $7.30/month each; the dev environment has two interface endpoints (Secrets Manager and Geo Places) totaling about $15/month. Lambda's own logs do not require a CloudWatch Logs interface endpoint.
+The **Dev Cost Control** workflow (`dev_cost_control.yml`) lets you toggle the dev environment's two interface endpoints (Secrets Manager and Geo Places) on or off when not actively developing. Lambda's own logs do not require a CloudWatch Logs interface endpoint. See the authoritative [cost analysis](aws.md#cost-analysis) instead of copying a monthly estimate here.
 
 ```bash
 # Disable to save costs

--- a/docs/deployment/multi-account-aws.md
+++ b/docs/deployment/multi-account-aws.md
@@ -332,7 +332,7 @@ Each environment's OIDC role restricts which GitHub contexts can assume it:
 
 ### Workflow Configuration
 
-All deployment workflows use OIDC. The key configuration:
+The Lambda, Lambda-management, and Terraform deployment workflows use OIDC. The legacy geodata-import workflow and Terraform integration-test job still require static access-key secrets. The OIDC configuration is:
 
 ```yaml
 permissions:
@@ -347,7 +347,7 @@ steps:
       aws-region: us-east-1
 ```
 
-No `AWS_ACCESS_KEY_ID` or `AWS_SECRET_ACCESS_KEY` secrets are needed.
+These OIDC-backed workflows do not need `AWS_ACCESS_KEY_ID` or `AWS_SECRET_ACCESS_KEY` secrets.
 
 ### IAM Permission Scoping
 

--- a/docs/deployment/workflows.md
+++ b/docs/deployment/workflows.md
@@ -174,18 +174,18 @@ Runs security scans.
 ### Development Environment
 
 ```yaml
-Environment: development
-Branch: development or feature/*
+Environment: dev
+Branch: development
 Lambda Stage: dev
-Vercel: Preview deployment
+Vercel: Development deployment
 ```
 
 ### Production Environment
 
 ```yaml
-Environment: production
+Environment: prod
 Branch: main
-Lambda Stage: production
+Lambda Stage: prod
 Vercel: Production deployment
 Keep-warm: Yes (4 minutes)
 X-Ray: Enabled
@@ -200,16 +200,14 @@ X-Ray: Enabled
 ### Development
 
 ```bash
-DOMAIN_NAME=api-dev.yourdomain.com
-CERTIFICATE_ARN=arn:aws:acm:us-east-1:...
+TF_VAR_DOMAIN_NAME=yourdomain.com
 DEVELOPMENT_API_URL=https://api-dev.yourdomain.com
 ```
 
 ### Production
 
 ```bash
-DOMAIN_NAME=api.yourdomain.com
-CERTIFICATE_ARN=arn:aws:acm:us-east-1:...
+TF_VAR_DOMAIN_NAME=yourdomain.com
 PRODUCTION_API_URL=https://api.yourdomain.com
 ```
 

--- a/docs/deployment/workflows.md
+++ b/docs/deployment/workflows.md
@@ -308,10 +308,10 @@ vercel rollback
 
 ### Dev VPC Endpoints Toggle
 
-The dev environment's two VPC endpoints (~$15/month at $0.01/hour per endpoint) can be disabled when you're not actively developing to save costs. Use the **Dev Cost Control** workflow:
+The dev environment's two VPC endpoints can be disabled when you're not actively developing. Use the **Dev Cost Control** workflow; see the authoritative [cost analysis](aws.md#cost-analysis) for current and measured figures.
 
 ```bash
-# Disable VPC endpoints (saves ~$15/mo)
+# Disable both dev VPC endpoints
 gh workflow run dev_cost_control.yml -f vpc_endpoints=disable
 
 # Re-enable before developing

--- a/docs/deployment/workflows.md
+++ b/docs/deployment/workflows.md
@@ -122,7 +122,7 @@ Actions → Lambda Management → Run workflow → Select action
 
 #### `geodata_import.yml`
 
-Runs geographic data imports using ECS Fargate.
+Retains the intended ECS Fargate workflow for geographic imports. No current Terraform environment provisions its ECS cluster or task definition, so the workflow is unavailable until an environment explicitly wires in `modules/geodata-import`.
 
 **Import Types:**
 
@@ -132,7 +132,7 @@ Runs geographic data imports using ECS Fargate.
 - `all-tiger` - Import all TIGER data
 - `custom` - Run custom import command
 
-**Process:**
+**Intended process after provisioning:**
 
 1. Configures import command
 2. Runs ECS task with geodata-import container

--- a/docs/deployment/workflows.md
+++ b/docs/deployment/workflows.md
@@ -326,15 +326,10 @@ When VPC endpoints are disabled, Lambda functions in the dev environment (which 
 
 ## Cost Monitoring
 
-The serverless architecture significantly reduces costs:
-
-- **Lambda**: Pay per invocation (~$5/month)
-- **Vercel**: Free tier or $20/month Pro
-- **DynamoDB**: Pay per request (~$1/month)
-- **Total**: ~$39/month vs $73/month for ECS
+Compute is essentially free at current traffic — Lambda does not even appear as a Cost Explorer line item. The bill is dominated by always-on resources: VPC interface endpoints, RDS, and WAF. See [Cost Analysis](aws.md#cost-analysis) for the measured per-service breakdown.
 
 Monitor usage:
 
-- AWS Cost Explorer for Lambda/DynamoDB
+- AWS Cost Explorer, grouped by service and then by usage type
 - Vercel Analytics for bandwidth
 - CloudWatch for detailed metrics

--- a/docs/development.md
+++ b/docs/development.md
@@ -114,8 +114,9 @@ flowchart TD
     %% Decision to deployment
     tests_complete --> app_deploy[Application Deployment]
 
-    %% Deployment to AWS
-    app_deploy --> ecs[Amazon ECS]
+    %% Deployment
+    app_deploy --> lambda[AWS Lambda<br/>Django backend]
+    app_deploy --> vercel[Vercel<br/>Next.js frontend]
 ```
 
 The CI/CD pipeline includes:
@@ -123,7 +124,7 @@ The CI/CD pipeline includes:
 - **Parallel Testing**: Frontend, backend, and infrastructure tests run simultaneously
 - **Code Quality**: Automated linting and formatting checks
 - **Full Stack Integration**: End-to-end testing across all components
-- **Automated Deployment**: Successful builds deploy to AWS ECS
+- **Automated Deployment**: Successful builds deploy the backend to AWS Lambda and the frontend to Vercel
 
 ### Running Tests
 
@@ -223,15 +224,18 @@ For detailed production setup, see the [Site Password Protection Guide](developm
 
 ## Project Structure
 
-```
+```text
 coalition-builder/
-├── backend/           # Django API
+├── backend/           # Django API (deployed to AWS Lambda via Zappa)
 │   ├── coalition/     # Main app
 │   ├── docs/          # Sphinx API docs
-│   └── scripts/       # Backend scripts
-├── frontend/          # React frontend
-├── ssr/               # Next.js SSR
+│   ├── scripts/       # Backend scripts
+│   └── handler.py     # Lambda entry point
+├── frontend/          # Next.js frontend (deployed to Vercel)
 ├── terraform/         # Infrastructure
+│   ├── environments/  # shared, prod, dev
+│   └── modules/       # Reusable modules
+├── scripts/           # Repo-level tooling
 └── docs/              # Main documentation
 ```
 

--- a/docs/development/automated-protection.md
+++ b/docs/development/automated-protection.md
@@ -27,7 +27,7 @@ The `deploy_infra.yml` workflow automatically:
 
 1. Reads secrets from GitHub repository
 2. Passes variables to Terraform configuration
-3. Updates ECS containers with new environment variables
+3. Updates Lambda environment variables
 4. Stores passwords securely in AWS Secrets Manager
 
 ## Development Environment

--- a/docs/development/automated-protection.md
+++ b/docs/development/automated-protection.md
@@ -1,14 +1,14 @@
 # Site Password Protection
 
-Coalition Builder provides automated password protection through environment variables and infrastructure deployment.
+Coalition Builder contains optional password-protection middleware for local and deployed runtimes. The current deployment workflows do not configure it automatically.
 
 ## Overview
 
-The system protects your site using multiple authentication layers:
+The repository contains these authentication layers:
 
-- **Next.js Middleware**: HTTP Basic Authentication in SSR container
-- **nginx Proxy**: Optional reverse proxy with HTTP Basic Authentication
-- **Django Middleware**: Session-based authentication for API endpoints
+- **Next.js proxy**: HTTP Basic Authentication for frontend routes
+- **nginx proxy**: Optional local reverse proxy with HTTP Basic Authentication
+- **Django middleware**: Session-based password protection for backend routes
 
 ## Production Management
 
@@ -16,7 +16,14 @@ The system protects your site using multiple authentication layers:
 
 The infrastructure workflow does not enable or update application-level password protection. It reads the selected GitHub Environment's `SITE_PASSWORD` secret as a Terraform variable and stores it in SSM Parameter Store and Secrets Manager, but it does not add `SITE_PASSWORD_ENABLED`, `SITE_USERNAME`, or `SITE_PASSWORD` to Lambda or Vercel.
 
-Both applications default password protection to disabled when those runtime variables are absent. Configure all three variables directly in each application runtime and redeploy before relying on this control; a Terraform deployment alone is insufficient.
+Both applications default password protection to disabled when their runtime variables are absent. Do not set these values only through the Lambda or Vercel consoles: the next application deployment can replace console-managed configuration.
+
+Before relying on this control in a deployed environment, wire the variables into the deployment pipelines and redeploy:
+
+- Lambda: add `SITE_PASSWORD_ENABLED` and `SITE_PASSWORD` to `backend/scripts/configure_zappa.py` and pass them from `deploy_lambda.yml`.
+- Vercel: pass `SITE_PASSWORD_ENABLED`, `SITE_USERNAME`, and `SITE_PASSWORD` from protected GitHub configuration in `deploy_frontend.yml`.
+
+Until both paths are implemented and verified, treat deployed password protection as unsupported.
 
 ### Infrastructure Integration
 
@@ -55,23 +62,22 @@ docker compose up -d
 
 ### Production
 
-- **Frontend Routes**: Protected by Next.js middleware
-- **API Routes**: Protected by Django middleware
-- **ALB Routing**: Automatically routes to protected containers
+- **Frontend routes**: The Next.js proxy can protect routes after its variables are wired into the Vercel deployment.
+- **Backend routes**: Django lockdown can protect routes after its variables are wired into the Lambda deployment.
+- **Current deployment state**: Neither workflow supplies those variables, so protection is disabled.
 
-## Repository Secrets
+## Deployment Inputs
 
-| Secret                  | Required | Description                           |
-| ----------------------- | -------- | ------------------------------------- |
-| `SITE_PASSWORD_ENABLED` | Yes      | Enable protection (`true` or `false`) |
-| `SITE_USERNAME`         | No\*     | HTTP Basic Auth username              |
-| `SITE_PASSWORD`         | No\*     | Site access password                  |
+No repository or environment secret currently enables protection by itself. When deployment support is implemented, use protected configuration with these meanings:
 
-\*Required when `SITE_PASSWORD_ENABLED` is `true`
+| Name                    | Runtime           | Description                                   |
+| ----------------------- | ----------------- | --------------------------------------------- |
+| `SITE_PASSWORD_ENABLED` | Lambda and Vercel | Enable protection (`true`, `1`, or `yes`)     |
+| `SITE_USERNAME`         | Vercel            | HTTP Basic Auth username; defaults to `admin` |
+| `SITE_PASSWORD`         | Lambda and Vercel | Password; required when protection is enabled |
 
 ## Security Features
 
-- **AWS Secrets Manager**: Production passwords stored securely
-- **Environment Variables**: Development configuration
-- **Multiple Layers**: Different protection methods for different access patterns
-- **Automatic Updates**: Changes deploy with infrastructure updates
+- **AWS storage**: Terraform stores `SITE_PASSWORD` in SSM Parameter Store and Secrets Manager.
+- **Local environment variables**: Enable and configure protection during development.
+- **Separate application layers**: Frontend and backend protection must be configured and verified independently.

--- a/docs/development/automated-protection.md
+++ b/docs/development/automated-protection.md
@@ -12,23 +12,21 @@ The system protects your site using multiple authentication layers:
 
 ## Production Management
 
-### GitHub Secrets Setup
+### Current Automation Boundary
 
-1. Go to **Settings** → **Secrets and variables** → **Actions**
-2. Add these repository secrets:
-   - `SITE_PASSWORD_ENABLED`: `true` or `false`
-   - `SITE_USERNAME`: Username for HTTP Basic Auth
-   - `SITE_PASSWORD`: Secure password for site access
-3. Push changes to the `terraform/` directory to trigger deployment
+The infrastructure workflow does not enable or update application-level password protection. It reads the selected GitHub Environment's `SITE_PASSWORD` secret as a Terraform variable and stores it in SSM Parameter Store and Secrets Manager, but it does not add `SITE_PASSWORD_ENABLED`, `SITE_USERNAME`, or `SITE_PASSWORD` to Lambda or Vercel.
+
+Both applications default password protection to disabled when those runtime variables are absent. Configure all three variables directly in each application runtime and redeploy before relying on this control; a Terraform deployment alone is insufficient.
 
 ### Infrastructure Integration
 
 The `deploy_infra.yml` workflow automatically:
 
-1. Reads secrets from GitHub repository
-2. Passes variables to Terraform configuration
-3. Updates Lambda environment variables
-4. Stores passwords securely in AWS Secrets Manager
+1. Reads `SITE_PASSWORD` from the selected GitHub Environment
+2. Passes it to Terraform as `TF_VAR_site_password`
+3. Stores it in SSM Parameter Store and AWS Secrets Manager
+
+It does not update Lambda or Vercel environment variables.
 
 ## Development Environment
 

--- a/docs/development/testing.md
+++ b/docs/development/testing.md
@@ -440,7 +440,6 @@ export DATABASE_URL=postgresql://postgres:postgres@localhost:5432/coalition_test
 export NODE_ENV=test
 export NEXT_PUBLIC_API_URL=http://localhost:8000/api
 
-# Disable external services in tests
+# Disable external email delivery in tests
 export EMAIL_BACKEND=django.core.mail.backends.locmem.EmailBackend
-export CACHE_URL=locmem://
 ```

--- a/docs/email-configuration.md
+++ b/docs/email-configuration.md
@@ -192,7 +192,7 @@ python manage.py shell
 # Inspect selected non-secret settings inside Lambda
 cd backend
 poetry run zappa invoke prod \
-  'import os; print({name: os.environ.get(name) for name in ("EMAIL_BACKEND", "DEFAULT_FROM_EMAIL", "SITE_URL")})' \
+  'from django.conf import settings; print(settings.EMAIL_BACKEND, settings.DEFAULT_FROM_EMAIL, settings.SITE_URL)' \
   --raw
 
 # Invoke an explicit send test

--- a/docs/email-configuration.md
+++ b/docs/email-configuration.md
@@ -190,15 +190,18 @@ poetry run zappa invoke prod \
 ### Common Issues
 
 1. **"Email address is not verified"**
+
    - You're in sandbox mode and trying to send to unverified address
    - Solution: Verify the recipient or request production access
 
 2. **"Connection timeout"** / emails appearing in CloudWatch instead of arriving
+
    - The Lambda cannot reach the SES SMTP endpoint from its private subnets
    - This is the known gap described at the top of this page
    - Solution: Add an SES interface VPC endpoint, switch to the SES API, or provide a NAT route
 
 3. **"Invalid credentials"**
+
    - SMTP credentials are incorrect
    - Solution: Regenerate SMTP credentials in SES console
 

--- a/docs/email-configuration.md
+++ b/docs/email-configuration.md
@@ -2,7 +2,11 @@
 
 ## Overview
 
-The Coalition Builder uses AWS Simple Email Service (SES) for sending transactional emails like endorsement verifications and admin notifications. Since the ECS tasks run in public subnets with internet access, we can use SES via SMTP.
+The Coalition Builder uses AWS Simple Email Service (SES) for sending transactional emails like endorsement verifications and admin notifications. Django is configured to reach SES over SMTP (`email-smtp.us-east-1.amazonaws.com:587`).
+
+> **⚠️ Known gap on Lambda.** This SMTP path does not currently work in the serverless deployment. The Lambda runs in private subnets whose route table has no default route, and there is no SES VPC endpoint — so outbound SMTP cannot leave the VPC. `SafeSMTPBackend` treats the failed connection as "SMTP unavailable" and falls back to writing messages to the console, which on Lambda means they land in CloudWatch logs and are never delivered. `configure_zappa.py` also sets no `EMAIL_HOST_USER` / `EMAIL_HOST_PASSWORD`. As of August 2026, `aws ses get-send-statistics` reports no sends.
+>
+> Fixing this requires one of: adding an SES VPC endpoint (interface endpoints for `email-smtp` are available), switching to the SES API over an existing egress path, or giving the Lambda subnets a NAT route. Note that each added interface endpoint costs about $7.44/month per account — see [Cost Analysis](deployment/aws.md#cost-analysis).
 
 ## Automated Setup with Terraform
 
@@ -130,9 +134,9 @@ aws secretsmanager create-secret \
   }'
 ```
 
-### 6. Update ECS Task Definition
+### 6. Expose the credentials to the Lambda
 
-The ECS task definition needs to pull these secrets. Add to your task definition:
+The Lambda reads its configuration from the environment variables baked into `zappa_settings.json`. Export the SES SMTP credentials before running `configure_zappa.py`, or fetch them from Secrets Manager at startup — the Lambda already has a Secrets Manager VPC endpoint and read permission.
 
 ```json
 "secrets": [
@@ -180,7 +184,7 @@ python manage.py shell
 ### 2. Test in Production
 
 ```bash
-# SSH into bastion or ECS task
+# SSH into the bastion, or use `zappa invoke prod` for the Lambda
 # Check environment variables are set
 env | grep EMAIL
 
@@ -204,9 +208,10 @@ python manage.py shell
    - You're in sandbox mode and trying to send to unverified address
    - Solution: Verify the recipient or request production access
 
-2. **"Connection timeout"**
-   - ECS task cannot reach SES endpoint
-   - Solution: Ensure ECS is in public subnet with internet access
+2. **"Connection timeout"** / emails appearing in CloudWatch instead of arriving
+   - The Lambda cannot reach the SES SMTP endpoint from its private subnets
+   - This is the known gap described at the top of this page
+   - Solution: Add an SES interface VPC endpoint, switch to the SES API, or provide a NAT route
 
 3. **"Invalid credentials"**
    - SMTP credentials are incorrect
@@ -236,8 +241,7 @@ LOGGING = {
 
 ## Cost Optimization
 
-- **First 62,000 emails/month from EC2/ECS**: Free
-- **Additional emails**: $0.10 per 1,000 emails
+- **Outbound email**: $0.10 per 1,000 emails (the 62,000/month free tier applies to sends from EC2/ECS, not Lambda)
 - **Data transfer**: $0.12 per GB of attachments
 
 For low-traffic sites, you'll likely stay within the free tier.
@@ -245,7 +249,7 @@ For low-traffic sites, you'll likely stay within the free tier.
 ## Security Best Practices
 
 1. **Never commit SMTP credentials** to version control
-2. **Use IAM roles** for ECS tasks instead of access keys when possible
+2. **Use IAM roles** for the Lambda execution role instead of access keys when possible
 3. **Enable DKIM signing** for better deliverability
 4. **Set up SPF records** in your DNS
 5. **Monitor for bounces and complaints** to maintain sender reputation

--- a/docs/email-configuration.md
+++ b/docs/email-configuration.md
@@ -165,15 +165,19 @@ python manage.py shell
 ### 2. Test in Production
 
 ```bash
-# SSH into the bastion, or use `zappa invoke prod` for the Lambda
-# Check environment variables are set
-env | grep EMAIL
+# Inspect selected non-secret settings inside Lambda
+cd backend
+poetry run zappa invoke prod \
+  'import os; print({name: os.environ.get(name) for name in ("EMAIL_BACKEND", "DEFAULT_FROM_EMAIL", "SITE_URL")})' \
+  --raw
 
-# Test sending
-python manage.py shell
->>> from django.core.mail import send_mail
->>> send_mail('Test Subject', 'Test message', None, ['verified@example.com'])
+# After PR #312 is merged and deployed, invoke an explicit send test
+poetry run zappa invoke prod \
+  'from django.core.mail import send_mail; print(send_mail("Test Subject", "Test message", None, ["verified@example.com"]))' \
+  --raw
 ```
+
+`zappa invoke` is not an interactive shell; it requires a function path or, as above, an explicit Python expression with `--raw`.
 
 ### 3. Monitor SES
 

--- a/docs/email-configuration.md
+++ b/docs/email-configuration.md
@@ -214,28 +214,23 @@ poetry run zappa invoke prod \
 ### Common Issues
 
 1. **"Email address is not verified"**
-
    - You're in sandbox mode and trying to send to unverified address
    - Solution: Verify the recipient or request production access
 
 2. **"Connection timeout" or a request that hangs until the Lambda times out**
-
    - The task cannot reach the SES endpoint. On Lambda this means the SES interface VPC endpoint is missing: the private subnets have no NAT and no default route, so the connection never completes rather than failing fast.
    - Solution: set `enable_ses_endpoint = true` for the environment. Confirm with `socket.gethostbyname("email.<region>.amazonaws.com")` from inside the function — it must return a private VPC address, not a public one.
    - For non-Lambda deployments, ensure the task has internet egress.
 
 3. **"Invalid credentials"**
-
    - SMTP credentials are incorrect
    - Solution: Regenerate SMTP credentials in SES console. On Lambda this error should not occur at all — it authenticates with the execution role, so check `sender_role_names` and the `ses:FromAddress` condition instead.
 
 4. **"Email address is not verified" for ordinary users**
-
    - The account is still in the SES sandbox, which only permits verified recipients. Sending to your own verified domain succeeds while every real endorser is rejected, so this can look like a partial outage.
    - Solution: request production access (see "Move Out of Sandbox" above), then confirm with `aws sesv2 get-account --query ProductionAccessEnabled`.
 
 5. **"Rate exceeded"**
-
    - Sending too many emails too quickly
    - Solution: Implement rate limiting or request higher SES limits
 

--- a/docs/email-configuration.md
+++ b/docs/email-configuration.md
@@ -226,10 +226,10 @@ LOGGING = {
 
 ## Cost Optimization
 
-- **Outbound email**: $0.10 per 1,000 emails (the 62,000/month free tier applies to sends from EC2/ECS, not Lambda)
+- **Outbound email**: Pricing depends on the account's SES plan. As of August 2026, à-la-carte sending is $0.10 per 1,000 emails while the default Essentials plan for new or inactive accounts starts at $0.16 per 1,000.
 - **Data transfer**: $0.12 per GB of attachments
 
-For low-traffic sites, you'll likely stay within the free tier.
+Free usage depends on the AWS account's credit or legacy free-tier eligibility. Check the [current SES pricing](https://aws.amazon.com/ses/pricing/) rather than assuming an EC2-specific allowance applies.
 
 ## Security Best Practices
 

--- a/docs/email-configuration.md
+++ b/docs/email-configuration.md
@@ -6,7 +6,7 @@ The Coalition Builder uses AWS Simple Email Service (SES) for sending transactio
 
 > **⚠️ Known gap on Lambda.** This SMTP path does not currently work in the serverless deployment. The Lambda runs in private subnets whose route table has no default route, and there is no SES VPC endpoint — so outbound SMTP cannot leave the VPC. `SafeSMTPBackend` treats the failed connection as "SMTP unavailable" and falls back to writing messages to the console, which on Lambda means they land in CloudWatch logs and are never delivered. `configure_zappa.py` also sets no `EMAIL_HOST_USER` / `EMAIL_HOST_PASSWORD`. As of August 2026, `aws ses get-send-statistics` reports no sends.
 >
-> Fixing this requires one of: adding an SES VPC endpoint (interface endpoints for `email-smtp` are available), switching to the SES API over an existing egress path, or giving the Lambda subnets a NAT route. Note that each added interface endpoint costs about $7.44/month per account — see [Cost Analysis](deployment/aws.md#cost-analysis).
+> [PR #312](https://github.com/lhadjchikh/coalition-builder/pull/312) is the concrete fix: it switches Lambda to the SES API, adds the required VPC endpoint and execution-role permissions, and makes delivery failures observable. Until that PR is merged and deployed, transactional email from Lambda remains unavailable.
 
 ## Automated Setup with Terraform
 
@@ -41,7 +41,7 @@ The module will:
 - Generate SMTP credentials with IAM user
 - **Automatically calculate the SMTP password** from the IAM secret
 - Store complete credentials in AWS Secrets Manager
-- Configure the ECS task to use them automatically
+- Preserve SMTP credentials for deployment targets that still use `SafeSMTPBackend`; the current Lambda deployment does not consume them
 
 ## AWS SES Setup
 
@@ -134,30 +134,11 @@ aws secretsmanager create-secret \
   }'
 ```
 
-### 6. Expose the credentials to the Lambda
+### 6. Lambda delivery
 
-The Lambda reads its configuration from the environment variables baked into `zappa_settings.json`. Export the SES SMTP credentials before running `configure_zappa.py`, or fetch them from Secrets Manager at startup — the Lambda already has a Secrets Manager VPC endpoint and read permission.
+There is no supported SMTP-credential injection path for the current Lambda deployment: `configure_zappa.py` does not copy the `EMAIL_*` variables, the runtime does not fetch the SMTP secret, and the Lambda role is not allowed to read it. The ECS-style `secrets` block previously shown here is not valid Zappa or Lambda configuration.
 
-```json
-"secrets": [
-  {
-    "name": "EMAIL_HOST",
-    "valueFrom": "arn:aws:secretsmanager:region:account:secret:coalition/email-config:EMAIL_HOST::"
-  },
-  {
-    "name": "EMAIL_HOST_USER",
-    "valueFrom": "arn:aws:secretsmanager:region:account:secret:coalition/email-config:EMAIL_HOST_USER::"
-  },
-  {
-    "name": "EMAIL_HOST_PASSWORD",
-    "valueFrom": "arn:aws:secretsmanager:region:account:secret:coalition/email-config:EMAIL_HOST_PASSWORD::"
-  },
-  {
-    "name": "DEFAULT_FROM_EMAIL",
-    "valueFrom": "arn:aws:secretsmanager:region:account:secret:coalition/email-config:DEFAULT_FROM_EMAIL::"
-  }
-]
-```
+Do not attempt to expose the static SMTP credentials to Lambda. [PR #312](https://github.com/lhadjchikh/coalition-builder/pull/312) replaces this design with SES API authentication through the Lambda execution role.
 
 ## Email Backend
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -79,7 +79,7 @@ flowchart TD
 - **Static & Media**: S3 behind CloudFront
 - **Infrastructure**: Terraform-managed AWS resources
 
-ECS Fargate is retained only for occasional TIGER geodata import tasks. The ALB, ECS service, and NAT gateway used by the pre-2025 deployment have been removed; see the [AWS Serverless Deployment guide](deployment/aws.md) for the resource inventory and cost breakdown.
+The repository retains ECS-based TIGER import scaffolding, but no current Terraform environment provisions it. The ALB, ECS application service, and NAT gateway used by the pre-2025 deployment have been removed; see the [AWS Serverless Deployment guide](deployment/aws.md) for the resource inventory and cost breakdown.
 
 ### Frontend Architecture
 
@@ -146,7 +146,7 @@ Comprehensive guides for managing your coalition platform:
 - **[Lambda Deployment](LAMBDA_DEPLOYMENT.md)** - Deploy Django to AWS Lambda with Zappa
 - **[Vercel Deployment](VERCEL_DEPLOYMENT.md)** - Deploy Next.js to Vercel Edge Network
 - **[GitHub Workflows](deployment/workflows.md)** - CI/CD pipelines for automated deployment
-- **[Geographic Data Import](deployment/geodata-import.md)** - Import TIGER shapefiles via ECS
+- **[Geographic Data Import](deployment/geodata-import.md)** - Retained ECS import design (not currently provisioned)
 
 ## Documentation
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -70,21 +70,16 @@ flowchart TD
 
 ## Architecture
 
-### Serverless Architecture (Current)
+### Serverless Architecture
 
-- **Backend**: Django API on AWS Lambda (via Zappa)
+- **Backend**: Django API on AWS Lambda (via Zappa, as a container image)
 - **Frontend**: Next.js on Vercel Edge Network
 - **Database**: PostgreSQL with PostGIS (RDS)
-- **Rate Limiting**: DynamoDB (serverless)
+- **Rate Limiting**: PostgreSQL-backed Django cache — see [Rate Limiting](rate-limiting.md)
+- **Static & Media**: S3 behind CloudFront
 - **Infrastructure**: Terraform-managed AWS resources
-- **Cost**: ~$39/month (46% reduction from ECS)
 
-### Legacy Architecture (Deprecated)
-
-- **Backend**: Django API on ECS Fargate
-- **Frontend**: Next.js on ECS with SSR
-- **Infrastructure**: ALB + ECS + NAT Gateway
-- **Cost**: ~$73/month
+ECS Fargate is retained only for occasional TIGER geodata import tasks. The ALB, ECS service, and NAT gateway used by the pre-2025 deployment have been removed; see the [AWS Serverless Deployment guide](deployment/aws.md) for the resource inventory and cost breakdown.
 
 ### Frontend Architecture
 
@@ -122,9 +117,9 @@ The `/frontend` directory contains a Next.js application that serves as the prim
 1. **[Installation](installation.md)** - Quick setup for development
 2. **[Configuration](configuration.md)** - Environment variables and settings
 3. **[Development](development.md)** - Development workflow and contributing
-4. **[Lambda Deployment](LAMBDA_DEPLOYMENT.md)** - Backend deployment to AWS Lambda
-5. **[Vercel Deployment](VERCEL_DEPLOYMENT.md)** - Frontend deployment to Vercel
-6. **[Legacy Deployment](deployment.md)** - ECS deployment (deprecated)
+4. **[Deployment Overview](deployment.md)** - How the serverless pieces fit together
+5. **[Lambda Deployment](LAMBDA_DEPLOYMENT.md)** - Backend deployment to AWS Lambda
+6. **[Vercel Deployment](VERCEL_DEPLOYMENT.md)** - Frontend deployment to Vercel
 
 ## User Guides
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -79,7 +79,7 @@ flowchart TD
 - **Static & Media**: S3 behind CloudFront
 - **Infrastructure**: Terraform-managed AWS resources
 
-The repository retains ECS-based TIGER import scaffolding, but no current Terraform environment provisions it. The ALB, ECS application service, and NAT gateway used by the pre-2025 deployment have been removed; see the [AWS Serverless Deployment guide](deployment/aws.md) for the resource inventory and cost breakdown.
+The repository retains ECS-based TIGER import scaffolding, but no current Terraform environment provisions it. The ALB, ECS application service, and NAT gateway used by the previous ECS deployment have been removed; see the [AWS Serverless Deployment guide](deployment/aws.md) for the resource inventory and cost breakdown.
 
 ### Frontend Architecture
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -41,7 +41,6 @@ docker compose exec api python manage.py createsuperuser
 - Python 3.13+
 - Node.js 22+
 - PostgreSQL 16+ with PostGIS extension
-- Redis (for caching)
 
 1. **Clone and setup backend:**
 

--- a/docs/rate-limiting.md
+++ b/docs/rate-limiting.md
@@ -281,7 +281,7 @@ The system previously used:
 The new database-backed approach:
 
 - Eliminates Redis dependency
-- Removes DynamoDB costs (~$1/month)
+- Removes the separate DynamoDB dependency and its associated cost
 - Provides consistent behavior everywhere
 - Simplifies deployment and testing
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -405,29 +405,39 @@ terraform graph | dot -Tpng > graph.png
 ### AWS CLI Commands
 
 ```bash
-# Deploy to ECS
-aws ecs update-service \
-    --cluster coalition-cluster \
-    --service coalition-backend \
-    --force-new-deployment
+# Deploy the backend (preferred: via GitHub Actions)
+gh workflow run deploy_lambda.yml --ref main -f environment=prod
 
-# Check deployment status
-aws ecs describe-services \
-    --cluster coalition-cluster \
-    --services coalition-backend
+# Update the Lambda image directly
+aws lambda update-function-code \
+    --function-name coalition-prod \
+    --image-uri "$ECR_REGISTRY/coalition-prod:latest"
 
-# View logs
-aws logs get-log-events \
-    --log-group-name /ecs/coalition-backend \
-    --log-stream-name stream-name
+# Check the deployed configuration
+aws lambda get-function-configuration --function-name coalition-prod
 
-# Update environment variables
-aws ecs describe-task-definition \
-    --task-definition coalition-backend \
-    --query taskDefinition > task-def.json
+# Tail logs
+aws logs tail /aws/lambda/coalition-prod --follow
 
-# Register new task definition
-aws ecs register-task-definition --cli-input-json file://task-def.json
+# Inspect costs by service, then drill into usage types
+aws ce get-cost-and-usage \
+    --time-period Start=2026-07-01,End=2026-08-01 \
+    --granularity MONTHLY --metrics UnblendedCost \
+    --group-by Type=DIMENSION,Key=SERVICE
+```
+
+### Zappa Commands
+
+```bash
+# Deploy or update a stage
+zappa deploy prod
+zappa update prod
+
+# Roll back to the previous version
+zappa rollback prod -n 1
+
+# Run a Django management command remotely
+zappa manage prod migrate
 ```
 
 ## NPM/Frontend Commands

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -428,16 +428,22 @@ aws ce get-cost-and-usage \
 
 ### Zappa Commands
 
+Run Zappa from `backend/`. `zappa_settings.json` is gitignored and must be generated from the same environment variables used by `deploy_lambda.yml`. Image deployments must receive a real, immutable ECR image URI; do not use the placeholder URI in the template.
+
 ```bash
-# Deploy or update a stage
-zappa deploy prod
-zappa update prod
+cd backend
+poetry install --only main
+poetry run python scripts/configure_zappa.py
+
+# Deploy or update a stage with an image that has already been built and pushed
+poetry run zappa deploy prod --docker-image-uri "$IMAGE_URI"
+poetry run zappa update prod --docker-image-uri "$IMAGE_URI"
 
 # Roll back to the previous version
-zappa rollback prod -n 1
+poetry run zappa rollback prod -n 1
 
 # Run a Django management command remotely
-zappa manage prod migrate
+poetry run zappa manage prod migrate
 ```
 
 ## NPM/Frontend Commands

--- a/docs/reference/environment.md
+++ b/docs/reference/environment.md
@@ -198,10 +198,9 @@ These settings can be customized to adjust spam detection sensitivity:
 ENDORSEMENT_RATE_LIMIT_WINDOW=300
 ENDORSEMENT_RATE_LIMIT_MAX_ATTEMPTS=3
 
-# Cache backend (required for rate limiting)
-# Redis recommended for production and development
-CACHE_URL=redis://localhost:6379/1
 ```
+
+Rate limiting uses Django's database cache backend, which needs no configuration — there is no `CACHE_URL` setting. See [Rate Limiting](../rate-limiting.md).
 
 **Note:** The spam prevention system includes built-in configurations for:
 
@@ -486,9 +485,6 @@ SITE_URL="http://localhost:3000"
 ENDORSEMENT_RATE_LIMIT_WINDOW=300
 ENDORSEMENT_RATE_LIMIT_MAX_ATTEMPTS=3
 
-# Cache (for rate limiting) - Redis container in docker compose
-CACHE_URL=redis://redis:6379/1
-
 # Frontend
 NEXT_PUBLIC_API_URL=http://localhost:8000/api
 REACT_APP_DEBUG=true
@@ -535,9 +531,6 @@ SITE_URL="https://yourdomain.com"
 # Endorsement System
 ENDORSEMENT_RATE_LIMIT_WINDOW=300
 ENDORSEMENT_RATE_LIMIT_MAX_ATTEMPTS=3
-
-# Cache (Redis recommended for production)
-CACHE_URL=redis://redis:6379/1
 
 # Storage
 USE_S3=True

--- a/docs/reference/environment.md
+++ b/docs/reference/environment.md
@@ -70,7 +70,7 @@ ADMIN_HELP_TECHNICAL_CONTACT="Technical support (support@example.org)"
 | `AWS_STORAGE_BUCKET_NAME` | S3 bucket name for media file uploads | -           | Production |
 | `AWS_REGION`              | AWS region for S3 bucket              | `us-east-1` | No         |
 
-**Note:** In production, media files (uploaded images) are automatically stored in AWS S3. The ECS task role provides authentication for S3 access.
+**Note:** In production, media files (uploaded images) are automatically stored in AWS S3. The Lambda execution role provides authentication for S3 access.
 
 **File Organization:**
 
@@ -379,7 +379,7 @@ AWS_STORAGE_BUCKET_NAME=coalition-static-assets-a4853294
 # Optional: Direct backend serving
 BACKEND_DOMAIN=api.yourdomain.com
 
-# Backend configuration (in ECS/production)
+# Backend configuration (in Lambda/production)
 USE_S3_DIRECT_URLS=false  # Use CloudFront URLs (recommended)
 # USE_S3_DIRECT_URLS=true  # Use S3 URLs directly
 ```

--- a/docs/reference/environment.md
+++ b/docs/reference/environment.md
@@ -576,9 +576,6 @@ SITE_URL="http://testserver"
 ENDORSEMENT_RATE_LIMIT_WINDOW=60
 ENDORSEMENT_RATE_LIMIT_MAX_ATTEMPTS=10
 
-# Cache for testing (in-memory)
-CACHE_URL=locmem://
-
 # Test Organization Settings
 ORGANIZATION_NAME="Test Coalition"
 ORG_TAGLINE="Testing advocacy partnerships"

--- a/docs/reference/environment.md
+++ b/docs/reference/environment.md
@@ -341,7 +341,6 @@ ANALYZE=true
 The backend (Django) generates image URLs based on its configuration:
 
 1. **When using CloudFront (recommended for production)**:
-
    - Backend has `CLOUDFRONT_DOMAIN` set and `USE_S3_DIRECT_URLS=false`
    - Image URLs look like: `https://d123456789.cloudfront.net/media/images/logo.jpg`
    - Next.js needs `CLOUDFRONT_DOMAIN` in build environment to allow these URLs

--- a/docs/serverless-setup.md
+++ b/docs/serverless-setup.md
@@ -1,5 +1,7 @@
 # Serverless Setup for Contributors
 
+> **Historical reference — not a deployment runbook.** This page describes the earlier hand-configured Zappa setup and includes obsolete credential and staging instructions. Use the current [Deployment Guide](deployment.md), [AWS Serverless Deployment](deployment/aws.md), and [Deployment Workflows](deployment/workflows.md) instead.
+
 This guide helps you set up your own AWS resources for deploying the Coalition Builder application using Lambda and Zappa.
 
 ## Why Configuration is Needed

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -53,6 +53,7 @@ nav:
   - Deployment:
       - Overview: deployment.md
       - AWS Deployment: deployment/aws.md
+      - Multi-Account AWS: deployment/multi-account-aws.md
       - Docker Deployment: deployment/docker.md
       - Lambda Deployment: LAMBDA_DEPLOYMENT.md
       - Vercel Deployment: VERCEL_DEPLOYMENT.md

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -23,7 +23,7 @@ Quick links:
 
 - **Terraform**: Infrastructure as Code (>= 1.12.0)
 - **AWS Provider**: ~> 5.99.0
-- **AWS Services**: Lambda, API Gateway, RDS PostgreSQL, S3, CloudFront, Secrets Manager, SES, AWS Location Service, ECS (TIGER imports only)
+- **AWS Services**: Lambda, API Gateway, RDS PostgreSQL, S3, CloudFront, Secrets Manager, SES, AWS Location Service
 - **Testing**: Terratest with AWS SDK Go v2
 - **Security**: WAF, Security Groups, KMS encryption
 
@@ -87,12 +87,6 @@ flowchart TB
         lambda --> rds[(RDS PostgreSQL<br/>with PostGIS<br/>+ rate-limit cache)]
         lambda --> s3[S3 Static Assets]
 
-        subgraph ecs_occasional["ECS (Occasional Use)"]
-            ecs_task[Fargate Task<br/>TIGER Data Import<br/>2 vCPU, 4GB RAM]
-        end
-
-        ecs_task --> rds
-
         subgraph security["Security & Monitoring"]
             secrets[Secrets Manager]
             cloudwatch[CloudWatch Logs]
@@ -123,7 +117,7 @@ Note that the bill is dominated by always-on resources (VPC interface endpoints,
 - **RDS PostgreSQL**: Database with PostGIS extension
 - **VPC endpoints**: Secrets Manager, CloudWatch Logs, and AWS Location, so the Lambda needs no NAT gateway
 - **Rate limiting**: PostgreSQL-backed Django cache (no DynamoDB or Redis)
-- **ECS Fargate**: TIGER shapefile imports (occasional use)
+- **TIGER imports**: An ECS Fargate module and workflow remain in the repository but are not instantiated by a current environment
 - **Vercel**: Next.js frontend with global CDN
 
 ### Security Features

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -4,7 +4,7 @@
 [![Terraform](https://img.shields.io/badge/terraform-1.12+-blue.svg)](https://www.terraform.io/)
 [![AWS Provider](https://img.shields.io/badge/aws-5.99+-orange.svg)](https://registry.terraform.io/providers/hashicorp/aws/latest)
 
-This directory contains the Terraform configuration for deploying Coalition Builder's serverless infrastructure to AWS. The infrastructure is designed to be secure, scalable, and cost-optimized with a 46% cost reduction from the previous ECS-based deployment.
+This directory contains the Terraform configuration for deploying Coalition Builder's serverless infrastructure to AWS. It replaces the previous ECS-based deployment, removing the ALB, the ECS application service, and the NAT gateway.
 
 ## 📚 Documentation
 
@@ -14,8 +14,8 @@ Quick links:
 
 - [Multi-Account AWS Guide](../docs/deployment/multi-account-aws.md) - Bootstrap, OIDC, VPC peering, environment workflow
 - [AWS Serverless Guide](../docs/deployment/aws.md) - Complete serverless deployment walkthrough
-- [Lambda Deployment](../docs/lambda_deployment.md) - Django on Lambda setup
-- [Vercel Deployment](../docs/vercel_deployment.md) - Next.js on Vercel setup
+- [Lambda Deployment](../docs/LAMBDA_DEPLOYMENT.md) - Django on Lambda setup
+- [Vercel Deployment](../docs/VERCEL_DEPLOYMENT.md) - Next.js on Vercel setup
 - [Configuration Reference](https://lhadjchikh.github.io/coalition-builder/reference/environment/) - All environment variables
 - [Deployment Overview](https://lhadjchikh.github.io/coalition-builder/deployment/) - Multiple deployment options
 
@@ -23,7 +23,7 @@ Quick links:
 
 - **Terraform**: Infrastructure as Code (>= 1.12.0)
 - **AWS Provider**: ~> 5.99.0
-- **AWS Services**: Lambda, API Gateway, RDS PostgreSQL, DynamoDB, S3, Secrets Manager, ECS (TIGER imports only)
+- **AWS Services**: Lambda, API Gateway, RDS PostgreSQL, S3, CloudFront, Secrets Manager, SES, AWS Location Service, ECS (TIGER imports only)
 - **Testing**: Terratest with AWS SDK Go v2
 - **Security**: WAF, Security Groups, KMS encryption
 
@@ -84,8 +84,7 @@ flowchart TB
     subgraph aws["AWS (us-east-1)"]
         apigateway --> lambda[Lambda Function<br/>Django via Zappa]
 
-        lambda --> rds[(RDS PostgreSQL<br/>with PostGIS)]
-        lambda --> dynamodb[(DynamoDB<br/>Rate Limiting)]
+        lambda --> rds[(RDS PostgreSQL<br/>with PostGIS<br/>+ rate-limit cache)]
         lambda --> s3[S3 Static Assets]
 
         subgraph ecs_occasional["ECS (Occasional Use)"]
@@ -110,18 +109,20 @@ flowchart TB
 
 ### Current: Serverless Benefits
 
-- **46% Cost Reduction**: ~$39/month vs ~$73/month (ECS)
 - **Auto-scaling**: Lambda scales to zero when idle
 - **Global Performance**: Vercel edge network
 - **Minimal Maintenance**: No server management required
-- **Pay-per-use**: DynamoDB and Lambda billing
+- **Pay-per-use**: Lambda and API Gateway billing — compute is effectively free at current traffic
+
+Note that the bill is dominated by always-on resources (VPC interface endpoints, RDS, WAF) rather than compute. See [Cost Analysis](../docs/deployment/aws.md#cost-analysis) for measured figures.
 
 ### Infrastructure Components
 
 - **Lambda**: Django API via Zappa (Python 3.13)
 - **API Gateway**: REST API with custom domains
 - **RDS PostgreSQL**: Database with PostGIS extension
-- **DynamoDB**: Serverless rate limiting (replaces Redis)
+- **VPC endpoints**: Secrets Manager, CloudWatch Logs, and AWS Location, so the Lambda needs no NAT gateway
+- **Rate limiting**: PostgreSQL-backed Django cache (no DynamoDB or Redis)
 - **ECS Fargate**: TIGER shapefile imports (occasional use)
 - **Vercel**: Next.js frontend with global CDN
 
@@ -136,10 +137,10 @@ flowchart TB
 
 ### Cost Optimization
 
-- **ECS in Public Subnets**: Eliminates NAT Gateway costs (~$45/month savings)
+- **No NAT Gateway**: Interface VPC endpoints replace it — cheaper than a NAT gateway, but still the largest line item on the bill
+- **Single-AZ endpoints**: `enable_single_az_endpoints` halves interface endpoint hours
 - **S3 Gateway Endpoint**: Free S3 access without data transfer costs
-- **Fargate Spot**: Option to use Spot instances for non-critical workloads
-- **Auto-scaling**: Automatic scaling based on demand
+- **Scale to zero**: Lambda incurs no cost when idle
 - **Budget Alerts**: Proactive cost monitoring and alerting
 
 ## Multi-Account Deployment
@@ -245,20 +246,9 @@ The infrastructure is designed with security best practices:
 
 ## Cost Estimation
 
-Typical monthly costs for a production deployment:
+Measured monthly costs are maintained in one place: [Cost Analysis](../docs/deployment/aws.md#cost-analysis).
 
-| Service                   | Configuration                | Estimated Cost |
-| ------------------------- | ---------------------------- | -------------- |
-| ECS Fargate               | 0.5 vCPU, 1GB RAM            | ~$20           |
-| RDS PostgreSQL            | db.t4g.micro                 | ~$15           |
-| Application Load Balancer | 1 ALB                        | ~$20           |
-| S3 & CloudFront           | 10GB storage, 100GB transfer | ~$10           |
-| Route53                   | 1 hosted zone                | ~$0.50         |
-| Secrets Manager           | 5 secrets                    | ~$2.50         |
-| CloudWatch                | Logs and metrics             | ~$5            |
-| **Total**                 |                              | **~$73/month** |
-
-_Note: Actual costs vary based on usage and region._
+The short version, from Cost Explorer for July 2026: **~~$82/month across all three accounts**. VPC interface endpoints are the largest single item (~$22/month each in prod and dev), ahead of RDS (~~$16/month). Lambda does not appear as a line item at current traffic.
 
 ## Support
 

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -242,7 +242,7 @@ The infrastructure is designed with security best practices:
 
 Measured monthly costs are maintained in one place: [Cost Analysis](../docs/deployment/aws.md#cost-analysis).
 
-The short version, from Cost Explorer for July 2026: **~~$82/month across all three accounts**. VPC interface endpoints are the largest single item (~$22/month each in prod and dev), ahead of RDS (~~$16/month). Lambda does not appear as a line item at current traffic.
+At current traffic, always-on networking and database resources dominate the bill while Lambda compute is negligible. Use the linked cost analysis for the dated measurements and exact figures.
 
 ## Support
 


### PR DESCRIPTION
The ECS-to-serverless migration is complete, but the repository's deployment documentation still mixed the retired ECS topology, obsolete credentials, and estimated costs with the current Lambda and Vercel system. This PR makes the documented architecture and runbooks match the deployed code, gives maintainers a reproducible measured-cost reference, and calls out retained scaffolding that is not currently usable.

## What this changes

The [README architecture](https://github.com/lhadjchikh/coalition-builder/blob/lhadjchikh/update-readme-serverless/README.md#%EF%B8%8F-architecture), [deployment guide](https://github.com/lhadjchikh/coalition-builder/blob/lhadjchikh/update-readme-serverless/docs/deployment.md), and [AWS inventory](https://github.com/lhadjchikh/coalition-builder/blob/lhadjchikh/update-readme-serverless/docs/deployment/aws.md) now describe Django on Lambda, Next.js on Vercel, the shared database VPC plus separate application VPCs, PostgreSQL-backed rate limiting, and the absence of always-on ECS application services or a NAT gateway. Transactional email is documented in its current post-#312 state: Lambda uses the SES API over the production VPC endpoint with execution-role authentication and explicit failure monitoring.

The deployment documentation now separates Lambda, Terraform, and frontend configuration scopes; qualifies the two remaining workflows that use static AWS keys; generates Terraform's gitignored backend configuration before `terraform init`; and avoids presenting placeholder Zappa image settings as a working manual deployment. Historical Lambda, Vercel, and hand-configured serverless pages carry prominent warnings and are no longer promoted from the README.

The [AWS cost analysis](https://github.com/lhadjchikh/coalition-builder/blob/lhadjchikh/update-readme-serverless/docs/deployment/aws.md#cost-analysis) is the single source for July 2026 measured costs. It records the Cost Explorer queries, the mapping from raw service and usage-type rows to displayed labels, rounding behavior, and the configuration changes made after that snapshot. Other pages link to it rather than maintaining separate monthly estimates.

Related corrections remove inert `CACHE_URL` examples, mark TIGER imports as unprovisioned, explain that deployed password protection is not wired into Lambda or Vercel, correct current RDS and IAM examples, and surface the staff-only operating guide added to Django admin.

## Where to focus

### For human reviewers

- Confirm that the three-account and three-VPC description matches the intended production architecture.
- Review the distinction between operational deployment workflows and retained historical or unprovisioned paths.
- Check that the Cost Explorer mapping is understandable enough for a future maintainer to refresh the snapshot without silently changing categories.
- Confirm that documenting password protection as unsupported until both deployment paths carry its variables is the right operational boundary.

### For an AI review agent

- Compare every documented GitHub secret and variable with the workflow expressions and Terraform variables that consume it.
- Verify command working directories, generated-file prerequisites, stage names, and container-image arguments against the current workflows.
- Search for remaining ECS, DynamoDB rate-limit, Redis cache, staging-deployment, SES SMTP-on-Lambda, and duplicated cost claims.
- Check internal links, Markdown formatting, and strict MkDocs navigation.

## Design notes

**Current runbooks take precedence over historical setup pages.** The old pages remain for context, but they are marked historical and removed from the README's quick links instead of being partially modernized into another parallel source of deployment truth.

**Measured costs stay a dated snapshot.** July figures are not rewritten to look like the current endpoint count. The guide explains the later Logs-to-SES endpoint swap and development Logs endpoint removal so readers can distinguish historical billing data from current Terraform.

**Architecture diagrams remain intentionally duplicated at different levels.** The README provides a newcomer summary while `docs/deployment/aws.md` remains the canonical resource and cost inventory. This carries a known drift risk; future architecture changes should update both in the same PR.

**No application behavior changes are introduced.** The only workflow edit updates the Dev Cost Control input description; application and infrastructure behavior remain unchanged.

## Known follow-up (not blocking)

- #316 tracks the mismatch between Secrets Manager's active database URLs and SSM's environment-suffixed database names. Resolving it safely requires Terraform and migration work outside this documentation PR.

## Validation

- `mkdocs build --clean --strict`
- Prettier checks for every changed Markdown, YAML, and example environment file
- `.github/scripts/test_deployment_workflows.sh`
- `git diff --check`
