### PR TITLE
docs: add AGENTS.md guide for AI coding agents

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -77,9 +77,8 @@ Terraform (the plan-only Terratests require valid AWS credentials):
 ```bash
 review_repo_root=$(git rev-parse --show-toplevel)
 terraform -chdir="$review_repo_root/terraform" fmt -recursive
-tflint --init --config="$review_repo_root/.tflint.hcl"
-tflint --chdir="$review_repo_root/terraform" --recursive \
-  --config="$review_repo_root/.tflint.hcl"
+tflint --chdir="$review_repo_root/terraform" --init
+tflint --chdir="$review_repo_root/terraform" --recursive
 cd "$review_repo_root/terraform/tests"
 go test -short -v -timeout 10m ./modules/       # plan-only; creates no AWS resources
 ```
@@ -150,9 +149,10 @@ styled-components with a theme from
 colocated in `__tests__/`. Live-stack tests belong in `__tests__/integration/`; mocked
 end-to-end-style tests live in `tests/e2e/`.
 
-**Terraform** — `terraform fmt -recursive` + recursive `tflint`. Pass the repository-root
-`.tflint.hcl` explicitly as shown above. Module changes should come with a Terratest case
-under `terraform/tests/modules/`.
+**Terraform** — `terraform fmt -recursive` + recursive `tflint`. CI runs TFLint from
+`terraform/` without loading the root `.tflint.hcl`; passing that config explicitly is
+stricter and currently reports baseline findings. Module changes should come with a Terratest
+case under `terraform/tests/modules/`.
 
 ## Gotchas
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -115,8 +115,8 @@ Matching CI exactly matters more than matching `scripts/lint.py`:
   in `.github/workflows/lint_prettier.yml`; `./scripts/lint.py` formats a narrower file set.
 - `npm run lint` only covers `app components lib proxy.ts`. `services/`, `utils/`,
   `hooks/`, `contexts/` are unlinted by that script — still keep them clean.
-- `npm run typecheck` uses `tsconfig.build.json`, which **excludes** test files. Type errors
-  in tests won't fail CI but will fail an editor using `tsconfig.json`.
+- `npm run typecheck` uses `tsconfig.build.json`, which **excludes** test files.
+  `tsconfig.json` also excludes tests, and no dedicated test typecheck currently covers them.
 
 ## Conventions
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,162 @@
+# AGENTS.md
+
+Guidance for AI coding agents working in this repository. Human-facing docs live in
+`README.md`, `docs/`, and <https://lhadjchikh.github.io/coalition-builder/>.
+
+## What this is
+
+Coalition Builder is a policy-advocacy platform: organizations run campaigns, recruit
+stakeholders, and collect verified endorsements tied to legislators and geographic regions.
+
+Three deployable pieces, one repo:
+
+| Piece        | Stack                                               | Runs on                        |
+| ------------ | --------------------------------------------------- | ------------------------------ |
+| `backend/`   | Django 5.2 + Django Ninja + GeoDjango/PostGIS, 3.13 | AWS Lambda (Zappa, Docker img) |
+| `frontend/`  | Next.js 16 App Router + React 19 + TypeScript       | Vercel                         |
+| `terraform/` | Terraform + Terratest (Go)                          | AWS (shared / prod / dev)      |
+
+The frontend proxies `/api/*` to the backend (see `frontend/proxy.ts`,
+`frontend/next.config.js`). Status: pre-alpha, no releases, architecture still moving.
+
+## Repo map
+
+```text
+backend/coalition/       Django project package
+  api/                   Django Ninja routers + schemas.py (one module per resource)
+  campaigns/             PolicyCampaign, Bill
+  content/               Homepage, ContentBlock, Image, Video, Theme + HTML sanitizer
+  core/                  settings.py, urls.py, middleware/, secrets.py, storage.py, email
+  endorsements/          Endorsement model, email verification, spam prevention
+  legal/  legislators/  regions/  stakeholders/
+  test_base.py           BaseTestCase / BaseTransactionTestCase (loads regions fixture)
+backend/scripts/         create_test_data.py, configure_zappa.py, build/deploy shell scripts
+frontend/
+  app/                   Next.js App Router pages (+ colocated __tests__/)
+  components/            React components (+ components/__tests__/)
+  lib/ services/ utils/ hooks/ contexts/ types/
+  __tests__/             Config/infra tests (proxy, next config, tailwind, build env)
+  tests/                 integration/ and e2e/ suites (separate jest configs)
+terraform/
+  environments/{shared,prod,dev}/   root modules
+  modules/                          ~16 modules (zappa, database, networking, ses, ...)
+  tests/                            Terratest Go suites + Makefile
+scripts/lint.py          Repo-wide auto-fixing lint driver
+docs/                    MkDocs source published to GitHub Pages
+.github/workflows/       CI; check_app.yml is the PR entry point
+```
+
+## Commands
+
+Backend (needs PostGIS + GDAL — use Docker unless you have GeoDjango deps locally):
+
+```bash
+docker compose up -d db                         # PostGIS 16 on :5432
+cd backend && poetry install
+poetry run pytest                               # full suite (coverage gate: 80%)
+poetry run pytest path/to/test_x.py --no-cov    # scoped run; --no-cov avoids the gate
+poetry run ruff format . && poetry run ruff check --fix .
+poetry run mypy coalition/ --config-file pyproject.toml
+```
+
+Frontend (Node >= 22 required by `package.json` engines; CI uses 22.x):
+
+```bash
+cd frontend && npm ci
+npm test                       # jest (jsdom)
+npm run test:integration       # jest.integration.config.js, node env, --runInBand
+npm run test:e2e               # needs a running backend
+npm run typecheck              # tsc -p tsconfig.build.json (excludes test files)
+npm run lint                   # eslint app components lib proxy.ts
+npm run format:check           # prettier
+```
+
+Terraform:
+
+```bash
+cd terraform && terraform fmt -recursive && tflint
+cd terraform/tests && make test-unit            # Terratest; see Makefile for targets
+```
+
+Whole repo, auto-fixing (Python + Prettier + TS + Terraform):
+
+```bash
+./scripts/lint.py
+```
+
+Full stack locally:
+
+```bash
+docker compose -f docker-compose.yml -f docker-compose.dev.yml up -d   # hot reload
+docker compose exec api python scripts/create_test_data.py
+# frontend :3000, API/admin :8000, nginx :80
+```
+
+## What CI actually enforces
+
+`check_app.yml` diffs against the base branch and runs only the affected suites
+(frontend / backend / terraform / fullstack); a docs-only diff skips everything.
+Matching CI exactly matters more than matching `scripts/lint.py`:
+
+- **Python format is `ruff format --check`, not Black.** `pyproject.toml` still configures
+  Black and `scripts/lint.py` still runs it. CI (`lint_python.yml`, `check_backend.yml`)
+  runs `ruff format --check . && ruff check . && mypy coalition/`. Use `ruff format`.
+- Backend tests run in the `dev` Docker target via `pytest -n auto --dist loadscope`.
+  Tests must be parallel-safe and not depend on cross-file ordering.
+- Coverage gate is `--cov-fail-under=80` in `addopts`, so it applies to every local run too.
+- Prettier is checked over the **whole repo**, not just `frontend/`: root
+  `*.{md,yml,yaml,json,css}` and `.github/workflows/*.yml` included. Run
+  `npm --prefix frontend run format:check` plus the root glob, or just `./scripts/lint.py`.
+- `npm run lint` only covers `app components lib proxy.ts`. `services/`, `utils/`,
+  `hooks/`, `contexts/` are unlinted by that script — still keep them clean.
+- `npm run typecheck` uses `tsconfig.build.json`, which **excludes** test files. Type errors
+  in tests won't fail CI but will fail an editor using `tsconfig.json`.
+
+## Conventions
+
+**Commits** — Conventional Commits with a scope, e.g. `fix(frontend): stabilize Next build
+type config`, `test(terraform): use synthetic deployment fixtures`. Never add co-authorship
+trailers.
+
+**Workflow** — TDD: write the failing test, confirm it fails, then implement minimally.
+Branch off `main`; PRs target `main`.
+
+**Python** — Ruff with a broad rule set (`ANN` annotations, `B`, `SIM`, `UP`, `T20` no
+prints, `ERA` no commented-out code) at line length 88. Every function is explicitly typed;
+`mypy` runs with the django-stubs plugin. Models live in a `models/` package (one class per
+module) once an app has more than one — see `campaigns/models/`, `content/models/`.
+
+**API** — One module per resource under `coalition/api/`, each exporting a `Router`
+registered in `api.py`. Response schemas go in `api/schemas.py`. Handlers take
+`request: HttpRequest`, declare `response=`, and carry a docstring — the public API docs are
+generated from these. CSRF is on for the whole `NinjaAPI`.
+
+**Backend tests** — Live in `<app>/tests/test_*.py`. Subclass `BaseTestCase` from
+`coalition/test_base.py` to get the `regions.json` fixture and `self.maryland` / `virginia`
+/ `california` plus a `create_stakeholder()` helper. Django `TestCase` style (unittest
+asserts), not bare pytest functions.
+
+**TypeScript/React** — Path aliases `@/`, `@components/`, `@services/`, etc. (mirrored in
+`jest.config.js` — update both). Prettier: 80 cols, double quotes, semicolons, es5 trailing
+commas. Styling is a mix of Tailwind and styled-components with a theme from
+`contexts/ThemeContext.tsx`; follow whichever the neighboring file uses. Unit tests are
+colocated in `__tests__/`; anything requiring a live backend belongs in `tests/e2e/`.
+
+**Terraform** — `terraform fmt -recursive` + `tflint` (`.tflint.hcl`). Module changes should
+come with a Terratest case under `terraform/tests/modules/`.
+
+## Gotchas
+
+- **`docs/` is partly stale.** It references an `ssr/` directory, a `frontend/src/` tree, a
+  `test:ci` npm script, and ECS deployment — none of which exist anymore (the app is on
+  Lambda + Vercel, components live at `frontend/components/`). Trust the code over `docs/`,
+  and fix docs you touch.
+- Lambda specifics that bite: GDAL libs are at `/opt/lib64/`, `GDAL_LIBRARY_PATH` is set
+  only inside the `if IS_LAMBDA:` branch of `settings.py` (so `collectstatic` at image build
+  time can't rely on it), and the Lambda has **no internet egress** — anything reaching a
+  public endpoint needs a VPC endpoint.
+- `settings.py` branches heavily on `IS_LAMBDA` and `ENVIRONMENT`; changes to config need
+  coverage in `coalition/core/tests/test_lambda_settings.py` and friends.
+- Local `node` may be v20 while `package.json` requires >= 22 — check before debugging odd
+  npm failures.
+- Do not push to GitHub or create releases unless explicitly asked.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -107,8 +107,8 @@ Matching CI exactly matters more than matching `scripts/lint.py`:
   Tests must be parallel-safe and not depend on cross-file ordering.
 - Coverage gate is `--cov-fail-under=80` in `addopts`, so it applies to every local run too.
 - Prettier is checked over the **whole repo**, not just `frontend/`: root
-  `*.{md,yml,yaml,json,css}` and `.github/workflows/*.yml` included. Run
-  `npm --prefix frontend run format:check` plus the root glob, or just `./scripts/lint.py`.
+  `*.{md,yml,yaml,json,css}` and `.github/workflows/*.yml` included. Use the exact commands
+  in `.github/workflows/lint_prettier.yml`; `./scripts/lint.py` formats a narrower file set.
 - `npm run lint` only covers `app components lib proxy.ts`. `services/`, `utils/`,
   `hooks/`, `contexts/` are unlinted by that script — still keep them clean.
 - `npm run typecheck` uses `tsconfig.build.json`, which **excludes** test files. Type errors

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -142,9 +142,10 @@ generated from these. CSRF is on for the whole `NinjaAPI`.
 / `california` plus a `create_stakeholder()` helper. Django `TestCase` style (unittest
 asserts), not bare pytest functions.
 
-**TypeScript/React** — Path aliases `@/`, `@components/`, `@services/`, etc. (mirrored in
-`jest.config.js` — update both). Prettier: 80 cols, double quotes, semicolons, es5 trailing
-commas. Styling is a mix of Tailwind and styled-components with a theme from
+**TypeScript/React** — Path aliases `@/`, `@components/`, `@services/`, etc. are mirrored in
+`tsconfig.json`, `tsconfig.build.json`, and `jest.config.js` — update all three. Prettier: 80
+cols, double quotes, semicolons, es5 trailing commas. Styling is a mix of Tailwind and
+styled-components with a theme from
 `contexts/ThemeContext.tsx`; follow whichever the neighboring file uses. Unit tests are
 colocated in `__tests__/`. Live-stack tests belong in `__tests__/integration/`; mocked
 end-to-end-style tests live in `tests/e2e/`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -146,9 +146,10 @@ asserts), not bare pytest functions.
 cols, double quotes, semicolons, es5 trailing commas. Also update
 `jest.integration.config.js` when live-stack tests use the alias. Styling is a mix of Tailwind
 and styled-components with a theme from
-`contexts/ThemeContext.tsx`; follow whichever the neighboring file uses. Unit tests are
-colocated in `__tests__/`. Live-stack tests belong in `__tests__/integration/`; mocked
-end-to-end-style tests live in `tests/e2e/`.
+`contexts/ThemeContext.tsx`; follow whichever the neighboring file uses. The default Jest
+config discovers tests only under `app/`, `components/`, `lib/`, `services/`, root
+`__tests__/`, and `tests/`; colocated suites elsewhere are not run. Live-stack tests belong
+in `__tests__/integration/`; mocked end-to-end-style tests live in `tests/e2e/`.
 
 **Terraform** — `terraform fmt -recursive` + recursive `tflint`. CI runs TFLint from
 `terraform/` without loading the root `.tflint.hcl`; passing that config explicitly is

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -74,7 +74,8 @@ npm run format:check           # prettier
 Terraform:
 
 ```bash
-cd terraform && terraform fmt -recursive && tflint
+cd terraform && terraform fmt -recursive
+tflint --init && tflint --recursive
 cd terraform/tests
 go test -short -v -timeout 10m ./modules/       # validation only; no AWS resources
 ```
@@ -143,8 +144,9 @@ commas. Styling is a mix of Tailwind and styled-components with a theme from
 `contexts/ThemeContext.tsx`; follow whichever the neighboring file uses. Unit tests are
 colocated in `__tests__/`; anything requiring a live backend belongs in `tests/e2e/`.
 
-**Terraform** — `terraform fmt -recursive` + `tflint` (`.tflint.hcl`). Module changes should
-come with a Terratest case under `terraform/tests/modules/`.
+**Terraform** — `terraform fmt -recursive` + `tflint --init` + `tflint --recursive`
+(`.tflint.hcl`). Module changes should come with a Terratest case under
+`terraform/tests/modules/`.
 
 ## Gotchas
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -75,7 +75,8 @@ Terraform:
 
 ```bash
 cd terraform && terraform fmt -recursive && tflint
-cd terraform/tests && make test-unit            # Terratest; see Makefile for targets
+cd terraform/tests
+go test -short -v -timeout 10m ./modules/       # validation only; no AWS resources
 ```
 
 Whole repo, auto-fixing (Python + Prettier + TS + Terraform):

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -52,6 +52,7 @@ Backend (needs PostGIS + GDAL — use Docker unless you have GeoDjango deps loca
 
 ```bash
 docker compose up -d db                         # PostGIS 16 on :5432
+export DATABASE_URL=postgis://coalition_admin:admin_password@localhost:5432/coalition
 cd backend && poetry install
 poetry run pytest                               # full suite (coverage gate: 80%)
 poetry run pytest path/to/test_x.py --no-cov    # scoped run; --no-cov avoids the gate

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -143,8 +143,9 @@ asserts), not bare pytest functions.
 
 **TypeScript/React** — Path aliases `@/`, `@components/`, `@services/`, etc. are mirrored in
 `tsconfig.json`, `tsconfig.build.json`, and `jest.config.js` — update all three. Prettier: 80
-cols, double quotes, semicolons, es5 trailing commas. Styling is a mix of Tailwind and
-styled-components with a theme from
+cols, double quotes, semicolons, es5 trailing commas. Also update
+`jest.integration.config.js` when live-stack tests use the alias. Styling is a mix of Tailwind
+and styled-components with a theme from
 `contexts/ThemeContext.tsx`; follow whichever the neighboring file uses. Unit tests are
 colocated in `__tests__/`. Live-stack tests belong in `__tests__/integration/`; mocked
 end-to-end-style tests live in `tests/e2e/`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -72,7 +72,7 @@ npm run lint                   # eslint app components lib proxy.ts
 npm run format:check           # prettier
 ```
 
-Terraform:
+Terraform (the plan-only Terratests require valid AWS credentials):
 
 ```bash
 review_repo_root=$(git rev-parse --show-toplevel)
@@ -81,7 +81,7 @@ tflint --init --config="$review_repo_root/.tflint.hcl"
 tflint --chdir="$review_repo_root/terraform" --recursive \
   --config="$review_repo_root/.tflint.hcl"
 cd "$review_repo_root/terraform/tests"
-go test -short -v -timeout 10m ./modules/       # validation only; no AWS resources
+go test -short -v -timeout 10m ./modules/       # plan-only; creates no AWS resources
 ```
 
 Whole repo, auto-fixing (Python + Prettier + TS + Terraform):

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -87,7 +87,7 @@ go test -short -v -timeout 10m ./modules/       # validation only; no AWS resour
 Whole repo, auto-fixing (Python + Prettier + TS + Terraform):
 
 ```bash
-./scripts/lint.py
+python3 scripts/lint.py
 ```
 
 Full stack locally:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -157,8 +157,8 @@ end-to-end-style tests live in `tests/e2e/`.
   and fix docs you touch.
 - Lambda specifics that bite: GDAL libs are at `/opt/lib64/`, `GDAL_LIBRARY_PATH` is set
   only inside the `if IS_LAMBDA:` branch of `settings.py` (so `collectstatic` at image build
-  time can't rely on it), and the Lambda has **no internet egress** — anything reaching a
-  public endpoint needs a VPC endpoint.
+  time can't rely on it), and the Lambda has **no internet egress**. Supported AWS services
+  require configured VPC endpoints; other public services need an explicit egress design.
 - `settings.py` branches heavily on `IS_LAMBDA` and `ENVIRONMENT`; changes to config need
   coverage in `coalition/core/tests/test_lambda_settings.py` and friends.
 - Local `node` may be v20 while `package.json` requires >= 22 — check before debugging odd

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -159,9 +159,9 @@ case under `terraform/tests/modules/`.
 ## Gotchas
 
 - **`docs/` is partly stale.** It references an `ssr/` directory, a `frontend/src/` tree, a
-  `test:ci` npm script, and ECS deployment — none of which exist anymore (the app is on
-  Lambda + Vercel, components live at `frontend/components/`). Trust the code over `docs/`,
-  and fix docs you touch.
+  `test:ci` npm script, and a legacy ECS application deployment — none of which exist anymore
+  (the app is on Lambda + Vercel, components live at `frontend/components/`). TIGER geodata
+  import still uses ECS Fargate. Trust the code over `docs/`, and fix docs you touch.
 - Lambda specifics that bite: GDAL libs are at `/opt/lib64/`, `GDAL_LIBRARY_PATH` is set
   only inside the `if IS_LAMBDA:` branch of `settings.py` (so `collectstatic` at image build
   time can't rely on it), and the Lambda has **no internet egress**. Supported AWS services

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -75,9 +75,12 @@ npm run format:check           # prettier
 Terraform:
 
 ```bash
-cd terraform && terraform fmt -recursive
-tflint --init && tflint --recursive
-cd terraform/tests
+review_repo_root=$(git rev-parse --show-toplevel)
+terraform -chdir="$review_repo_root/terraform" fmt -recursive
+tflint --init --config="$review_repo_root/.tflint.hcl"
+tflint --chdir="$review_repo_root/terraform" --recursive \
+  --config="$review_repo_root/.tflint.hcl"
+cd "$review_repo_root/terraform/tests"
 go test -short -v -timeout 10m ./modules/       # validation only; no AWS resources
 ```
 
@@ -146,9 +149,9 @@ commas. Styling is a mix of Tailwind and styled-components with a theme from
 colocated in `__tests__/`. Live-stack tests belong in `__tests__/integration/`; mocked
 end-to-end-style tests live in `tests/e2e/`.
 
-**Terraform** — `terraform fmt -recursive` + `tflint --init` + `tflint --recursive`
-(`.tflint.hcl`). Module changes should come with a Terratest case under
-`terraform/tests/modules/`.
+**Terraform** — `terraform fmt -recursive` + recursive `tflint`. Pass the repository-root
+`.tflint.hcl` explicitly as shown above. Module changes should come with a Terratest case
+under `terraform/tests/modules/`.
 
 ## Gotchas
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,8 +35,8 @@ frontend/
   app/                   Next.js App Router pages (+ colocated __tests__/)
   components/            React components (+ components/__tests__/)
   lib/ services/ utils/ hooks/ contexts/ types/
-  __tests__/             Config/infra tests (proxy, next config, tailwind, build env)
-  tests/                 integration/ and e2e/ suites (separate jest configs)
+  __tests__/             Config/infra tests + integration/ live-stack suite
+  tests/                 integration/ (excluded by Jest) + mocked e2e/ suite
 terraform/
   environments/{shared,prod,dev}/   root modules
   modules/                          ~16 modules (zappa, database, networking, ses, ...)
@@ -64,8 +64,8 @@ Frontend (Node >= 22 required by `package.json` engines; CI uses 22.x):
 ```bash
 cd frontend && npm ci
 npm test                       # jest (jsdom)
-npm run test:integration       # jest.integration.config.js, node env, --runInBand
-npm run test:e2e               # needs a running backend
+npm run test:integration       # live API, frontend, and nginx stack required
+npm run test:e2e               # mocked API suite; no backend required
 npm run typecheck              # tsc -p tsconfig.build.json (excludes test files)
 npm run lint                   # eslint app components lib proxy.ts
 npm run format:check           # prettier
@@ -142,7 +142,8 @@ asserts), not bare pytest functions.
 `jest.config.js` — update both). Prettier: 80 cols, double quotes, semicolons, es5 trailing
 commas. Styling is a mix of Tailwind and styled-components with a theme from
 `contexts/ThemeContext.tsx`; follow whichever the neighboring file uses. Unit tests are
-colocated in `__tests__/`; anything requiring a live backend belongs in `tests/e2e/`.
+colocated in `__tests__/`. Live-stack tests belong in `__tests__/integration/`; mocked
+end-to-end-style tests live in `tests/e2e/`.
 
 **Terraform** — `terraform fmt -recursive` + `tflint --init` + `tflint --recursive`
 (`.tflint.hcl`). Module changes should come with a Terratest case under


### PR DESCRIPTION
This PR adds a root [`AGENTS.md`](https://github.com/lhadjchikh/coalition-builder/blob/lhadjchikh/write-agents-md/AGENTS.md) that gives coding agents a verified map of the repository, safe commands for each deployable, the checks CI actually runs, and the conventions that should guide future changes. Its main risk control is preventing agents from relying on stale documentation, silently skipping tests or lint rules, or running infrastructure commands with incorrect assumptions.

## What this changes

The guide explains the Django/PostGIS backend on Lambda, the Next.js frontend on Vercel, and the Terraform-managed AWS environments in one place. It maps the active source and test locations and calls out legacy documentation that still describes the former application layout and deployment model.

The command section records the prerequisites and side effects that are easy to miss: host backend tests need an explicit PostGIS URL, the frontend live-stack and mocked suites are different commands, short-mode Terratests require AWS credentials but do not create resources, and the repository-wide lint driver must be invoked through Python.

The CI and conventions sections document selective workflow routing, repository-wide Prettier coverage, excluded TypeScript tests, Jest's current discovery roots, every configuration that mirrors path aliases, Lambda's lack of general internet egress, and the remaining ECS Fargate workflow for TIGER geodata import.

## Where to focus

### For human reviewers

- Decide whether the prescriptive conventions reflect the patterns we want agents to follow even where legacy code has exceptions, especially model packaging and API schema placement.
- Treat known lint and test-discovery gaps as non-blocking follow-up owned by PR #309, not as review findings for this documentation-only PR.

### For an AI review agent

- Re-run every documented command mentally against shell working-directory state, credentials, environment variables, and configuration discovery.
- Verify repository maps, test discovery, typecheck exclusions, deployment claims, and path-alias synchronization against the current branch.
- Treat a passing existing test or check as evidence only when it would fail under a plausible incorrect version of the documented behavior.
- Do not re-raise the known lint or Jest discovery gaps; review whether the guide describes their current behavior accurately.

## Design notes

- **Code and workflows are authoritative.** When current source or CI disagrees with older prose documentation, the guide follows the implementation and names the drift.
- **Operational prerequisites are explicit.** The guide distinguishes non-provisioning Terraform plans from credential-free checks and separates VPC endpoints for supported AWS services from the egress design required by arbitrary public services.
- **Current behavior is documented without pretending it is ideal.** The [Terraform lint workflow](https://github.com/lhadjchikh/coalition-builder/blob/lhadjchikh/write-agents-md/.github/workflows/lint_terraform.yml) does not load the repository-root [`.tflint.hcl`](https://github.com/lhadjchikh/coalition-builder/blob/lhadjchikh/write-agents-md/.tflint.hcl); explicitly loading it is stricter and currently surfaces baseline findings.
- **The PR stays documentation-only.** Broader lint and test configuration changes belong in [PR #309](https://github.com/lhadjchikh/coalition-builder/pull/309) so this guide can land without altering application or infrastructure behavior.

## Known follow-up (not blocking)

- [PR #309 — Align lint config with CI](https://github.com/lhadjchikh/coalition-builder/pull/309) is the intended home for lint and test-discovery cleanup. Its current diff implements Ruff/Black and ESLint alignment; Jest discovery expansion should be confirmed there rather than treated as blocking here.

## Validation

- [Prettier Linting](https://github.com/lhadjchikh/coalition-builder/actions/runs/31285435869/job/93173226011) passed on the converged head.
- [Documentation-only workflow completion](https://github.com/lhadjchikh/coalition-builder/actions/runs/31285436026/job/93173244406) passed; application suites were skipped by the documented change router.
