### PR TITLE
fix: deliver transactional email from Lambda via the SES API

### DIFF
--- a/.github/workflows/deploy_lambda.yml
+++ b/.github/workflows/deploy_lambda.yml
@@ -50,8 +50,10 @@ jobs:
           AWS_STORAGE_BUCKET_NAME: ${{ vars.AWS_STORAGE_BUCKET_NAME }}
           CLOUDFRONT_DOMAIN: ${{ vars.CLOUDFRONT_DOMAIN }}
           DATABASE_SECRET_ARN: ${{ secrets.DATABASE_SECRET_ARN }}
+          DEFAULT_FROM_EMAIL: ${{ vars.DEFAULT_FROM_EMAIL }}
           DEPLOYMENT_API_URL: ${{ steps.deployment_environment.outputs.environment == 'prod' && vars.PRODUCTION_API_URL || vars.DEVELOPMENT_API_URL }}
           DJANGO_SECRET_ARN: ${{ secrets.DJANGO_SECRET_ARN }}
+          SITE_URL: ${{ vars.SITE_URL }}
           VPC_SECURITY_GROUP_IDS: ${{ vars.VPC_SECURITY_GROUP_IDS }}
           VPC_SUBNET_IDS: ${{ vars.VPC_SUBNET_IDS }}
           ZAPPA_ROLE_NAME: ${{ vars.ZAPPA_ROLE_NAME }}
@@ -71,7 +73,9 @@ jobs:
           )
 
           if [[ "${{ steps.deployment_environment.outputs.environment }}" == "prod" ]]; then
-            required_names+=(CLOUDFRONT_DOMAIN)
+            # Without these, prod still sends mail — but from an address SES
+            # rejects, carrying verification links to http://localhost:3000.
+            required_names+=(CLOUDFRONT_DOMAIN SITE_URL DEFAULT_FROM_EMAIL)
           fi
 
           for required_name in "${required_names[@]}"; do
@@ -196,6 +200,12 @@ jobs:
           DATABASE_SECRET_ARN: ${{ secrets.DATABASE_SECRET_ARN }}
           DJANGO_SECRET_ARN: ${{ secrets.DJANGO_SECRET_ARN }}
           ZAPPA_ROLE_NAME: ${{ vars.ZAPPA_ROLE_NAME }}
+          # Email delivery settings baked into the Lambda environment
+          SITE_URL: ${{ vars.SITE_URL }}
+          API_URL: ${{ steps.deployment_environment.outputs.environment == 'prod' && vars.PRODUCTION_API_URL || vars.DEVELOPMENT_API_URL }}
+          DEFAULT_FROM_EMAIL: ${{ vars.DEFAULT_FROM_EMAIL }}
+          ADMIN_NOTIFICATION_EMAILS: ${{ vars.ADMIN_NOTIFICATION_EMAILS }}
+          SES_CONFIGURATION_SET: ${{ vars.SES_CONFIGURATION_SET }}
         run: |
           poetry run python scripts/configure_zappa.py
           poetry run zappa save-python-settings-file "${DEPLOYMENT_ENVIRONMENT}"

--- a/.github/workflows/dev_cost_control.yml
+++ b/.github/workflows/dev_cost_control.yml
@@ -4,20 +4,12 @@ on:
   workflow_dispatch:
     inputs:
       vpc_endpoints:
-        description: "VPC endpoints (disable to save at least ~$14.88/mo)"
+        description: "VPC Endpoints (disable to save ~$22/mo when not developing)"
         required: true
         type: choice
         options:
           - enable
           - disable
-      ses_endpoint:
-        description: "SES API endpoint (adds ~$7.44/mo while enabled)"
-        required: true
-        default: disable
-        type: choice
-        options:
-          - disable
-          - enable
 
 permissions:
   contents: read
@@ -39,7 +31,6 @@ jobs:
       TF_VAR_github_repo: ${{ vars.REPO_FULL_NAME }}
       TF_VAR_alert_email: ${{ vars.TF_VAR_ALERT_EMAIL }}
       TF_VAR_enable_vpc_endpoints: ${{ github.event.inputs.vpc_endpoints == 'enable' && 'true' || 'false' }}
-      TF_VAR_enable_ses_endpoint: ${{ github.event.inputs.vpc_endpoints == 'enable' && github.event.inputs.ses_endpoint == 'enable' && 'true' || 'false' }}
 
     steps:
       - name: Checkout
@@ -92,19 +83,13 @@ jobs:
       - name: Summary
         env:
           ACTION: ${{ github.event.inputs.vpc_endpoints }}
-          SES_ENDPOINT: ${{ github.event.inputs.ses_endpoint }}
         run: |
           if [ "$ACTION" = "enable" ]; then
             echo "### VPC Endpoints Enabled" >> $GITHUB_STEP_SUMMARY
             echo "Dev VPC endpoints are now **active**. Lambda can reach AWS services via private networking." >> $GITHUB_STEP_SUMMARY
-            if [ "$SES_ENDPOINT" = "enable" ]; then
-              echo "The SES API endpoint is **temporarily enabled** for connectivity testing and adds ~\$7.44/mo while active." >> $GITHUB_STEP_SUMMARY
-            else
-              echo "The SES API endpoint is **disabled**." >> $GITHUB_STEP_SUMMARY
-            fi
           else
             echo "### VPC Endpoints Disabled" >> $GITHUB_STEP_SUMMARY
-            echo "Dev VPC endpoints are now **disabled**, saving ~\$15/mo with the default endpoint set." >> $GITHUB_STEP_SUMMARY
+            echo "Dev VPC endpoints are now **disabled**, saving ~\$22/mo." >> $GITHUB_STEP_SUMMARY
             echo "" >> $GITHUB_STEP_SUMMARY
-            echo "> **Note:** Lambda functions in the dev VPC will not be able to access Secrets Manager, Geo Places, or SES while endpoints are disabled (no internet egress and no VPC endpoints)." >> $GITHUB_STEP_SUMMARY
+            echo "> **Note:** Lambda functions in the dev VPC will not be able to access Secrets Manager, CloudWatch Logs, or Geo Places at all while endpoints are disabled (no internet egress and no VPC endpoints)." >> $GITHUB_STEP_SUMMARY
           fi

--- a/.github/workflows/dev_cost_control.yml
+++ b/.github/workflows/dev_cost_control.yml
@@ -4,12 +4,20 @@ on:
   workflow_dispatch:
     inputs:
       vpc_endpoints:
-        description: "VPC Endpoints (disable to save ~$22/mo when not developing)"
+        description: "VPC endpoints (disable to save at least ~$14.88/mo)"
         required: true
         type: choice
         options:
           - enable
           - disable
+      ses_endpoint:
+        description: "SES API endpoint (adds ~$7.44/mo while enabled)"
+        required: true
+        default: disable
+        type: choice
+        options:
+          - disable
+          - enable
 
 permissions:
   contents: read
@@ -31,6 +39,7 @@ jobs:
       TF_VAR_github_repo: ${{ vars.REPO_FULL_NAME }}
       TF_VAR_alert_email: ${{ vars.TF_VAR_ALERT_EMAIL }}
       TF_VAR_enable_vpc_endpoints: ${{ github.event.inputs.vpc_endpoints == 'enable' && 'true' || 'false' }}
+      TF_VAR_enable_ses_endpoint: ${{ github.event.inputs.vpc_endpoints == 'enable' && github.event.inputs.ses_endpoint == 'enable' && 'true' || 'false' }}
 
     steps:
       - name: Checkout
@@ -83,13 +92,19 @@ jobs:
       - name: Summary
         env:
           ACTION: ${{ github.event.inputs.vpc_endpoints }}
+          SES_ENDPOINT: ${{ github.event.inputs.ses_endpoint }}
         run: |
           if [ "$ACTION" = "enable" ]; then
             echo "### VPC Endpoints Enabled" >> $GITHUB_STEP_SUMMARY
             echo "Dev VPC endpoints are now **active**. Lambda can reach AWS services via private networking." >> $GITHUB_STEP_SUMMARY
+            if [ "$SES_ENDPOINT" = "enable" ]; then
+              echo "The SES API endpoint is **temporarily enabled** for connectivity testing and adds ~\$7.44/mo while active." >> $GITHUB_STEP_SUMMARY
+            else
+              echo "The SES API endpoint is **disabled**." >> $GITHUB_STEP_SUMMARY
+            fi
           else
             echo "### VPC Endpoints Disabled" >> $GITHUB_STEP_SUMMARY
-            echo "Dev VPC endpoints are now **disabled**, saving ~\$22/mo." >> $GITHUB_STEP_SUMMARY
+            echo "Dev VPC endpoints are now **disabled**, saving ~\$15/mo with the default endpoint set." >> $GITHUB_STEP_SUMMARY
             echo "" >> $GITHUB_STEP_SUMMARY
-            echo "> **Note:** Lambda functions in the dev VPC will not be able to access Secrets Manager, CloudWatch Logs, or Geo Places at all while endpoints are disabled (no internet egress and no VPC endpoints)." >> $GITHUB_STEP_SUMMARY
+            echo "> **Note:** Lambda functions in the dev VPC will not be able to access Secrets Manager, Geo Places, or SES while endpoints are disabled (no internet egress and no VPC endpoints)." >> $GITHUB_STEP_SUMMARY
           fi

--- a/backend/coalition/api/tests/test_endorsements.py
+++ b/backend/coalition/api/tests/test_endorsements.py
@@ -727,14 +727,14 @@ class EndorsementAPIEnhancedTest(BaseTestCase):
 
         # First 3 should succeed
         for i in range(3):
-            assert (
-                responses[i].status_code == 200
-            ), f"Request {i + 1} should succeed but got {responses[i].status_code}"
+            assert responses[i].status_code == 200, (
+                f"Request {i + 1} should succeed but got {responses[i].status_code}"
+            )
 
         # 4th request should be rate limited
-        assert (
-            responses[3].status_code == 429
-        ), f"Request 4 should be rate limited but got {responses[3].status_code}"
+        assert responses[3].status_code == 429, (
+            f"Request 4 should be rate limited but got {responses[3].status_code}"
+        )
         data = responses[3].json()
         assert "too many" in data["detail"].lower()
 

--- a/backend/coalition/api/tests/test_endorsements.py
+++ b/backend/coalition/api/tests/test_endorsements.py
@@ -4,10 +4,12 @@ Tests for endorsement API endpoints.
 
 import json
 import uuid
-from unittest.mock import patch
+from unittest.mock import Mock, patch
 
+from botocore.exceptions import ClientError
 from django.contrib.auth.models import User
 from django.core.cache import cache
+from django.http import HttpResponse
 from django.test import Client
 
 from coalition.campaigns.models import PolicyCampaign
@@ -26,6 +28,75 @@ def get_valid_form_metadata() -> dict[str, str]:
         "ip_address": "192.168.1.100",
         "session_id": "test-session-123",
     }
+
+
+class EndorsementSurvivesEmailOutageTest(BaseTestCase):
+    """A broken mail path must not cost the user their submission.
+
+    ``create_endorsement`` sends the verification email inside
+    ``transaction.atomic``, so an exception escaping the email layer would
+    roll back the stakeholder, endorsement and terms acceptance and return a
+    500. The submission must persist and stay resendable instead.
+    """
+
+    def setUp(self) -> None:
+        super().setUp()
+        cache.clear()
+        self.client = Client()
+        self.campaign = PolicyCampaign.objects.create(
+            name="outage-campaign",
+            title="Outage Campaign",
+            summary="A campaign used to test email outages",
+            allow_endorsements=True,
+        )
+
+    def submit_endorsement(self) -> HttpResponse:
+        return self.client.post(
+            "/api/endorsements/",
+            data=json.dumps(
+                {
+                    "campaign_id": self.campaign.id,
+                    "stakeholder": {
+                        "first_name": "Dana",
+                        "last_name": "Reed",
+                        "email": "dana@example.com",
+                        "street_address": "1 Main St",
+                        "city": "Baltimore",
+                        "state": "MD",
+                        "zip_code": "21201",
+                        "type": "individual",
+                    },
+                    "statement": "I support this campaign",
+                    "public_display": True,
+                    "terms_accepted": True,
+                    "form_metadata": get_valid_form_metadata(),
+                },
+            ),
+            content_type="application/json",
+        )
+
+    @patch("coalition.endorsements.email_service.send_mail")
+    def test_endorsement_persists_when_mail_transport_fails(
+        self,
+        mock_send_mail: Mock,
+    ) -> None:
+        mock_send_mail.side_effect = ClientError(
+            {"Error": {"Code": "MessageRejected", "Message": "not verified"}},
+            "SendEmail",
+        )
+
+        response = self.submit_endorsement()
+
+        assert response.status_code == 200, response.content
+        stakeholder = Stakeholder.objects.get(email="dana@example.com")
+        endorsement = Endorsement.objects.get(
+            stakeholder=stakeholder,
+            campaign=self.campaign,
+        )
+        assert endorsement.statement == "I support this campaign"
+        # Never marked as sent, so the verification email can be resent.
+        assert endorsement.verification_sent_at is None
+        assert endorsement.email_verified is False
 
 
 class EndorsementAPITest(BaseTestCase):
@@ -656,14 +727,14 @@ class EndorsementAPIEnhancedTest(BaseTestCase):
 
         # First 3 should succeed
         for i in range(3):
-            assert responses[i].status_code == 200, (
-                f"Request {i + 1} should succeed but got {responses[i].status_code}"
-            )
+            assert (
+                responses[i].status_code == 200
+            ), f"Request {i + 1} should succeed but got {responses[i].status_code}"
 
         # 4th request should be rate limited
-        assert responses[3].status_code == 429, (
-            f"Request 4 should be rate limited but got {responses[3].status_code}"
-        )
+        assert (
+            responses[3].status_code == 429
+        ), f"Request 4 should be rate limited but got {responses[3].status_code}"
         data = responses[3].json()
         assert "too many" in data["detail"].lower()
 

--- a/backend/coalition/core/email_backend.py
+++ b/backend/coalition/core/email_backend.py
@@ -1,13 +1,13 @@
 """
-Custom email backend with fallback for development and error handling
+SMTP email backend that refuses to fail silently
 """
 
 import logging
-import socket
 from collections.abc import Sequence
 from typing import Any
 
 from django.conf import settings
+from django.core.exceptions import ImproperlyConfigured
 from django.core.mail.backends.console import EmailBackend as ConsoleBackend
 from django.core.mail.backends.smtp import EmailBackend as SMTPBackend
 from django.core.mail.message import EmailMessage
@@ -16,62 +16,48 @@ logger = logging.getLogger(__name__)
 
 
 class SafeSMTPBackend(SMTPBackend):
-    """
-    SMTP backend that falls back to console output if SMTP is not configured
-    or connection fails. This is useful for development and prevents the
-    application from hanging when email is not properly configured.
+    """SMTP backend that prints to the console in DEBUG and raises otherwise.
+
+    Local development gets console output so it never needs a mail server.
+    Everywhere else a delivery failure is raised: reporting success for mail
+    that was only written to a log leaves users waiting forever for a
+    verification link that will never arrive, and hides the outage from
+    monitoring.
     """
 
     def __init__(self, *args: Any, **kwargs: Any) -> None:
-        # Override timeout to be shorter (10 seconds instead of default)
         kwargs.setdefault("timeout", 10)
         super().__init__(*args, **kwargs)
         self.console_backend = ConsoleBackend()
 
     def send_messages(self, email_messages: Sequence[EmailMessage]) -> int:
-        """
-        Try to send via SMTP, fall back to console if it fails
-        """
         if not email_messages:
             return 0
 
-        # Check if SMTP is configured
-        if not self.host or not self.port:
-            logger.warning(
-                "SMTP not configured (missing host/port), logging emails to console. "
-                "Configure EMAIL_HOST and EMAIL_PORT environment variables.",
-            )
-            return self.console_backend.send_messages(email_messages)
-
-        # In debug mode, always use console
         if settings.DEBUG:
             return self.console_backend.send_messages(email_messages)
 
-        try:
-            # Try to connect with a short timeout
-            with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
-                sock.settimeout(3)  # 3 second timeout for connection test
-                result = sock.connect_ex((self.host, self.port))
-                if result != 0:
-                    logger.warning(
-                        f"Cannot connect to SMTP server {self.host}:{self.port}, "
-                        "logging emails to console instead.",
-                    )
-                    return self.console_backend.send_messages(email_messages)
-        except (TimeoutError, socket.gaierror, OSError) as e:
-            logger.warning(
-                f"SMTP connection test failed: {e}, logging emails to console",
-            )
-            return self.console_backend.send_messages(email_messages)
+        self._require_smtp_configuration()
 
-        # Try to send via SMTP
         try:
             return super().send_messages(email_messages)
-        except Exception as e:
-            logger.error(f"Failed to send email via SMTP: {e}")
-            # In production, raise the exception to avoid silent failure
-            # In development/testing, fall back to console
-            if not settings.DEBUG and not getattr(settings, "TESTING", False):
-                raise
-            logger.info("Falling back to console email output")
-            return self.console_backend.send_messages(email_messages)
+        except Exception:
+            logger.exception(
+                "SMTP delivery failed for %d message(s) via %s:%s",
+                len(email_messages),
+                self.host,
+                self.port,
+            )
+            raise
+
+    def _require_smtp_configuration(self) -> None:
+        missing = [
+            name
+            for name, value in (("EMAIL_HOST", self.host), ("EMAIL_PORT", self.port))
+            if not value
+        ]
+        if missing:
+            raise ImproperlyConfigured(
+                f"Cannot send email: {' and '.join(missing)} is not configured. "
+                "Refusing to discard mail silently outside DEBUG.",
+            )

--- a/backend/coalition/core/ses_backend.py
+++ b/backend/coalition/core/ses_backend.py
@@ -22,9 +22,9 @@ from django.core.mail.message import EmailMessage
 logger = logging.getLogger(__name__)
 
 # Bounded so a hung SES call cannot consume the whole Lambda timeout.
-_CONNECT_TIMEOUT_SECONDS = 5
-_READ_TIMEOUT_SECONDS = 10
-_MAX_ATTEMPTS = 3
+_CONNECT_TIMEOUT_SECONDS = 3
+_READ_TIMEOUT_SECONDS = 5
+_TOTAL_MAX_ATTEMPTS = 1
 
 
 class SESEmailBackend(BaseEmailBackend):
@@ -51,7 +51,10 @@ class SESEmailBackend(BaseEmailBackend):
                 config=Config(
                     connect_timeout=_CONNECT_TIMEOUT_SECONDS,
                     read_timeout=_READ_TIMEOUT_SECONDS,
-                    retries={"max_attempts": _MAX_ATTEMPTS, "mode": "standard"},
+                    retries={
+                        "total_max_attempts": _TOTAL_MAX_ATTEMPTS,
+                        "mode": "standard",
+                    },
                 ),
             )
         return self._client

--- a/backend/coalition/core/ses_backend.py
+++ b/backend/coalition/core/ses_backend.py
@@ -1,0 +1,101 @@
+"""
+Email backend that delivers through the Amazon SES API.
+
+Lambda runs in private subnets with no internet egress, so SES SMTP
+(``email-smtp.<region>.amazonaws.com:587``) is unreachable. The SES API is
+reachable over the ``com.amazonaws.<region>.email`` interface endpoint and
+authenticates with the function's execution role, so no static SMTP
+credentials are needed.
+"""
+
+import logging
+from collections.abc import Sequence
+from typing import Any
+
+import boto3
+from botocore.config import Config
+from botocore.exceptions import BotoCoreError, ClientError
+from django.conf import settings
+from django.core.mail.backends.base import BaseEmailBackend
+from django.core.mail.message import EmailMessage
+
+logger = logging.getLogger(__name__)
+
+# Bounded so a hung SES call cannot consume the whole Lambda timeout.
+_CONNECT_TIMEOUT_SECONDS = 5
+_READ_TIMEOUT_SECONDS = 10
+_MAX_ATTEMPTS = 3
+
+
+class SESEmailBackend(BaseEmailBackend):
+    """Send mail via the SES v2 API using the ambient AWS credentials.
+
+    Delivery failures are raised unless the caller opted into
+    ``fail_silently``; a swallowed failure is indistinguishable from a
+    delivered verification email and leaves users permanently stuck.
+    """
+
+    def __init__(self, fail_silently: bool = False, **kwargs: Any) -> None:
+        # Django's send_mail() always passes username/password; the base class
+        # accepts and discards them, which is what SES role auth wants.
+        super().__init__(fail_silently=fail_silently, **kwargs)
+        self._client: Any | None = None
+        self._configuration_set: str = getattr(settings, "SES_CONFIGURATION_SET", "")
+
+    @property
+    def client(self) -> Any:
+        """Lazily build and reuse one SES client for the process."""
+        if self._client is None:
+            self._client = boto3.client(
+                "sesv2",
+                config=Config(
+                    connect_timeout=_CONNECT_TIMEOUT_SECONDS,
+                    read_timeout=_READ_TIMEOUT_SECONDS,
+                    retries={"max_attempts": _MAX_ATTEMPTS, "mode": "standard"},
+                ),
+            )
+        return self._client
+
+    def send_messages(self, email_messages: Sequence[EmailMessage]) -> int:
+        """Send each message, returning how many SES accepted."""
+        return sum(self._send(message) for message in email_messages)
+
+    def _send(self, message: EmailMessage) -> bool:
+        recipients = message.recipients()
+        if not recipients:
+            return False
+
+        try:
+            response = self.client.send_email(**self._build_request(message))
+        except (BotoCoreError, ClientError):
+            logger.exception(
+                "SES delivery failed for %d recipient(s) from %s",
+                len(recipients),
+                message.from_email,
+            )
+            if not self.fail_silently:
+                raise
+            return False
+
+        logger.info(
+            "SES accepted message %s for %d recipient(s)",
+            response.get("MessageId", "<unknown>"),
+            len(recipients),
+        )
+        return True
+
+    def _build_request(self, message: EmailMessage) -> dict[str, Any]:
+        """Build the SendEmail request for one Django message.
+
+        Recipients are passed explicitly rather than parsed from the MIME
+        headers so that Bcc addresses are delivered without being disclosed
+        in the message itself.
+        """
+        request: dict[str, Any] = {
+            "FromEmailAddress": message.from_email,
+            "Destination": {"ToAddresses": list(message.recipients())},
+            "Content": {"Raw": {"Data": message.message().as_bytes(linesep="\r\n")}},
+        }
+        if self._configuration_set:
+            request["ConfigurationSetName"] = self._configuration_set
+        return request

--- a/backend/coalition/core/settings.py
+++ b/backend/coalition/core/settings.py
@@ -491,17 +491,24 @@ if DEBUG:
     # Development: Log emails to console
     EMAIL_BACKEND = "django.core.mail.backends.console.EmailBackend"
 else:
-    # Production: Use AWS SES via SMTP or custom backend
-    # For AWS SES SMTP, use: email-smtp.us-east-1.amazonaws.com
-    EMAIL_BACKEND = os.getenv(
-        "EMAIL_BACKEND",
-        "coalition.core.email_backend.SafeSMTPBackend",
+    # Lambda runs in private subnets with no internet egress, so SES SMTP is
+    # unreachable there; the SES API is reachable over a VPC interface
+    # endpoint and authenticates with the execution role. Other production
+    # deployments (containers with egress) keep using SES over SMTP.
+    _default_email_backend = (
+        "coalition.core.ses_backend.SESEmailBackend"
+        if IS_LAMBDA
+        else "coalition.core.email_backend.SafeSMTPBackend"
     )
+    EMAIL_BACKEND = os.getenv("EMAIL_BACKEND", _default_email_backend)
     EMAIL_HOST = os.getenv("EMAIL_HOST", "email-smtp.us-east-1.amazonaws.com")
     EMAIL_PORT = int(os.getenv("EMAIL_PORT", "587"))
     EMAIL_USE_TLS = os.getenv("EMAIL_USE_TLS", "True").lower() in ("true", "1", "t")
     EMAIL_HOST_USER = os.getenv("EMAIL_HOST_USER")  # SES SMTP username
     EMAIL_HOST_PASSWORD = os.getenv("EMAIL_HOST_PASSWORD")  # SES SMTP password
+
+# SES configuration set that records bounces, complaints and deliveries.
+SES_CONFIGURATION_SET = os.getenv("SES_CONFIGURATION_SET", "")
 
 # Default sender for system emails
 DEFAULT_FROM_EMAIL = os.getenv("DEFAULT_FROM_EMAIL", CONTACT_EMAIL)

--- a/backend/coalition/core/tests/test_email_backend.py
+++ b/backend/coalition/core/tests/test_email_backend.py
@@ -1,193 +1,80 @@
 """
 Tests for the SafeSMTPBackend email backend
+
+The backend deliberately has two modes: in DEBUG it prints to the console so
+local development never needs a mail server, and outside DEBUG every failure
+is raised so a broken mail path cannot masquerade as a delivered email.
 """
 
-import socket
+from smtplib import SMTPAuthenticationError, SMTPServerDisconnected
 from typing import Any
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
 import pytest
+from django.core.exceptions import ImproperlyConfigured
 from django.core.mail import EmailMessage
-from django.test import override_settings
 
 from coalition.core.email_backend import SafeSMTPBackend
 
 
-class TestSafeSMTPBackend:
-    """Test the SafeSMTPBackend class"""
+def make_message() -> EmailMessage:
+    return EmailMessage("Test", "Body", "from@example.com", ["to@example.com"])
 
-    def test_init_sets_timeout(self) -> None:
-        """Test that initialization sets a timeout"""
-        backend = SafeSMTPBackend()
-        assert backend.timeout == 10
+
+class TestSafeSMTPBackendConfiguration:
+    """Construction and configuration handling"""
+
+    def test_init_sets_default_timeout(self) -> None:
+        assert SafeSMTPBackend().timeout == 10
 
     def test_init_with_custom_timeout(self) -> None:
-        """Test initialization with custom timeout"""
-        backend = SafeSMTPBackend(timeout=5)
-        assert backend.timeout == 5
+        assert SafeSMTPBackend(timeout=5).timeout == 5
 
     def test_send_empty_messages_returns_zero(self) -> None:
-        """Test sending empty list of messages returns 0"""
-        backend = SafeSMTPBackend()
-        result = backend.send_messages([])
-        assert result == 0
+        assert SafeSMTPBackend().send_messages([]) == 0
 
-    @patch("coalition.core.email_backend.SMTPBackend.send_messages")
-    def test_send_messages_success(self, mock_send: Any) -> None:
-        """Test successful sending via SMTP"""
-        mock_send.return_value = 1
 
+class TestSafeSMTPBackendInDebug:
+    """In DEBUG the console stands in for a real mail server"""
+
+    @pytest.fixture(autouse=True)
+    def _debug_mode(self, settings: Any) -> None:
+        settings.DEBUG = True
+
+    def test_console_is_used_even_when_smtp_is_configured(self) -> None:
         backend = SafeSMTPBackend(host="smtp.example.com", port=587)
-        message = EmailMessage("Test", "Body", "from@example.com", ["to@example.com"])
+        message = make_message()
 
-        with patch("socket.socket") as mock_socket:
-            mock_sock_instance = MagicMock()
-            mock_sock_instance.connect_ex.return_value = 0  # Success
-            mock_socket.return_value.__enter__.return_value = mock_sock_instance
-
+        with patch.object(backend.console_backend, "send_messages") as mock_console:
+            mock_console.return_value = 1
             result = backend.send_messages([message])
 
         assert result == 1
-        mock_send.assert_called_once()
+        mock_console.assert_called_once_with([message])
 
-    def test_send_messages_no_host_falls_back_to_console(self) -> None:
-        """Test that missing host falls back to console"""
-        backend = SafeSMTPBackend()  # No host/port configured
+    def test_console_is_used_when_smtp_is_not_configured(self) -> None:
+        backend = SafeSMTPBackend()
         backend.host = None
 
-        message = EmailMessage("Test", "Body", "from@example.com", ["to@example.com"])
-
         with patch.object(backend.console_backend, "send_messages") as mock_console:
             mock_console.return_value = 1
-            result = backend.send_messages([message])
+            result = backend.send_messages([make_message()])
 
         assert result == 1
-        mock_console.assert_called_once_with([message])
 
-    def test_send_messages_no_port_falls_back_to_console(self) -> None:
-        """Test that missing port falls back to console"""
-        backend = SafeSMTPBackend(host="smtp.example.com")
-        backend.port = None
-
-        message = EmailMessage("Test", "Body", "from@example.com", ["to@example.com"])
-
-        with patch.object(backend.console_backend, "send_messages") as mock_console:
-            mock_console.return_value = 1
-            result = backend.send_messages([message])
-
-        assert result == 1
-        mock_console.assert_called_once()
-
-    @override_settings(DEBUG=True)
-    def test_send_messages_debug_mode_uses_console(self) -> None:
-        """Test that DEBUG mode always uses console"""
-        backend = SafeSMTPBackend(host="smtp.example.com", port=587)
-        message = EmailMessage("Test", "Body", "from@example.com", ["to@example.com"])
-
-        with patch.object(backend.console_backend, "send_messages") as mock_console:
-            mock_console.return_value = 1
-            result = backend.send_messages([message])
-
-        assert result == 1
-        mock_console.assert_called_once_with([message])
-
-    def test_send_messages_connection_refused_falls_back(self) -> None:
-        """Test fallback when SMTP connection is refused"""
-        backend = SafeSMTPBackend(host="smtp.example.com", port=587)
-        message = EmailMessage("Test", "Body", "from@example.com", ["to@example.com"])
-
-        with patch("socket.socket") as mock_socket:
-            mock_sock_instance = MagicMock()
-            mock_sock_instance.connect_ex.return_value = 1  # Connection refused
-            mock_socket.return_value.__enter__.return_value = mock_sock_instance
-
-            with patch.object(backend.console_backend, "send_messages") as mock_console:
-                mock_console.return_value = 1
-                result = backend.send_messages([message])
-
-        assert result == 1
-        mock_console.assert_called_once()
-
-    def test_send_messages_socket_timeout_falls_back(self) -> None:
-        """Test fallback when socket times out"""
-        backend = SafeSMTPBackend(host="smtp.example.com", port=587)
-        message = EmailMessage("Test", "Body", "from@example.com", ["to@example.com"])
-
-        with patch("socket.socket") as mock_socket:
-            mock_socket.side_effect = TimeoutError("Connection timed out")
-
-            with patch.object(backend.console_backend, "send_messages") as mock_console:
-                mock_console.return_value = 1
-                result = backend.send_messages([message])
-
-        assert result == 1
-        mock_console.assert_called_once()
-
-    def test_send_messages_socket_gaierror_falls_back(self) -> None:
-        """Test fallback when hostname resolution fails"""
-        backend = SafeSMTPBackend(host="invalid.hostname.local", port=587)
-        message = EmailMessage("Test", "Body", "from@example.com", ["to@example.com"])
-
-        with patch("socket.socket") as mock_socket:
-            mock_socket.side_effect = socket.gaierror("Name resolution failed")
-
-            with patch.object(backend.console_backend, "send_messages") as mock_console:
-                mock_console.return_value = 1
-                result = backend.send_messages([message])
-
-        assert result == 1
-        mock_console.assert_called_once()
-
-    @override_settings(DEBUG=True)
     @patch("coalition.core.email_backend.SMTPBackend.send_messages")
-    def test_send_messages_smtp_exception_falls_back(self, mock_send: Any) -> None:
-        """Test fallback when SMTP sending fails in DEBUG mode"""
-        mock_send.side_effect = Exception("SMTP Error")
-
+    def test_smtp_is_never_attempted(self, mock_send: Any) -> None:
         backend = SafeSMTPBackend(host="smtp.example.com", port=587)
-        message = EmailMessage("Test", "Body", "from@example.com", ["to@example.com"])
 
-        with patch("socket.socket") as mock_socket:
-            mock_sock_instance = MagicMock()
-            mock_sock_instance.connect_ex.return_value = 0  # Connection OK
-            mock_socket.return_value.__enter__.return_value = mock_sock_instance
+        with patch.object(backend.console_backend, "send_messages") as mock_console:
+            mock_console.return_value = 1
+            backend.send_messages([make_message()])
 
-            with patch.object(backend.console_backend, "send_messages") as mock_console:
-                mock_console.return_value = 1
-                result = backend.send_messages([message])
+        mock_send.assert_not_called()
 
-        assert result == 1
-        mock_console.assert_called_once()
-
-    @override_settings(DEBUG=False)
-    @patch("coalition.core.email_backend.SMTPBackend.send_messages")
-    def test_send_messages_smtp_exception_raises_in_production(
-        self,
-        mock_send: Any,
-    ) -> None:
-        """Test that SMTP exceptions are raised in production"""
-        mock_send.side_effect = Exception("SMTP Error")
-
-        backend = SafeSMTPBackend(host="smtp.example.com", port=587)
-        message = EmailMessage("Test", "Body", "from@example.com", ["to@example.com"])
-
-        with patch("socket.socket") as mock_socket:
-            mock_sock_instance = MagicMock()
-            mock_sock_instance.connect_ex.return_value = 0  # Connection OK
-            mock_socket.return_value.__enter__.return_value = mock_sock_instance
-
-            with pytest.raises(Exception, match="SMTP Error"):
-                backend.send_messages([message])
-
-    def test_send_multiple_messages(self) -> None:
-        """Test sending multiple messages"""
+    def test_multiple_messages_go_to_console_together(self) -> None:
         backend = SafeSMTPBackend()
-        backend.host = None  # Force console backend
-
-        messages = [
-            EmailMessage("Test1", "Body1", "from@example.com", ["to1@example.com"]),
-            EmailMessage("Test2", "Body2", "from@example.com", ["to2@example.com"]),
-        ]
+        messages = [make_message(), make_message()]
 
         with patch.object(backend.console_backend, "send_messages") as mock_console:
             mock_console.return_value = 2
@@ -195,3 +82,73 @@ class TestSafeSMTPBackend:
 
         assert result == 2
         mock_console.assert_called_once_with(messages)
+
+
+class TestSafeSMTPBackendInProduction:
+    """Outside DEBUG, mail must be delivered or the failure must be raised"""
+
+    @pytest.fixture(autouse=True)
+    def _production_mode(self, settings: Any) -> None:
+        settings.DEBUG = False
+
+    @patch("coalition.core.email_backend.SMTPBackend.send_messages")
+    def test_successful_send_returns_count(self, mock_send: Any) -> None:
+        mock_send.return_value = 1
+        backend = SafeSMTPBackend(host="smtp.example.com", port=587)
+
+        assert backend.send_messages([make_message()]) == 1
+        mock_send.assert_called_once()
+
+    @patch("coalition.core.email_backend.SMTPBackend.send_messages")
+    def test_unreachable_server_raises_instead_of_logging_to_console(
+        self,
+        mock_send: Any,
+    ) -> None:
+        """The failure mode that silently broke production endorsement email."""
+        mock_send.side_effect = SMTPServerDisconnected("Connection unexpectedly closed")
+        backend = SafeSMTPBackend(host="email-smtp.us-east-1.amazonaws.com", port=587)
+
+        with (
+            patch.object(backend.console_backend, "send_messages") as mock_console,
+            pytest.raises(SMTPServerDisconnected),
+        ):
+            backend.send_messages([make_message()])
+
+        mock_console.assert_not_called()
+
+    @patch("coalition.core.email_backend.SMTPBackend.send_messages")
+    def test_connection_timeout_raises(self, mock_send: Any) -> None:
+        mock_send.side_effect = TimeoutError("timed out")
+        backend = SafeSMTPBackend(host="email-smtp.us-east-1.amazonaws.com", port=587)
+
+        with pytest.raises(TimeoutError):
+            backend.send_messages([make_message()])
+
+    @patch("coalition.core.email_backend.SMTPBackend.send_messages")
+    def test_bad_credentials_raise(self, mock_send: Any) -> None:
+        mock_send.side_effect = SMTPAuthenticationError(535, b"Authentication failed")
+        backend = SafeSMTPBackend(host="smtp.example.com", port=587)
+
+        with pytest.raises(SMTPAuthenticationError):
+            backend.send_messages([make_message()])
+
+    def test_missing_host_raises_rather_than_discarding_mail(self) -> None:
+        backend = SafeSMTPBackend()
+        backend.host = None
+
+        with pytest.raises(ImproperlyConfigured, match="EMAIL_HOST"):
+            backend.send_messages([make_message()])
+
+    def test_missing_port_raises_rather_than_discarding_mail(self) -> None:
+        backend = SafeSMTPBackend(host="smtp.example.com")
+        backend.port = None
+
+        with pytest.raises(ImproperlyConfigured, match="EMAIL_PORT"):
+            backend.send_messages([make_message()])
+
+    def test_empty_messages_still_returns_zero_without_configuration(self) -> None:
+        """Nothing to send is not a misconfiguration."""
+        backend = SafeSMTPBackend()
+        backend.host = None
+
+        assert backend.send_messages([]) == 0

--- a/backend/coalition/core/tests/test_ses_backend.py
+++ b/backend/coalition/core/tests/test_ses_backend.py
@@ -1,0 +1,199 @@
+"""
+Tests for the SES API email backend used by Lambda
+"""
+
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+from botocore.exceptions import ClientError, EndpointConnectionError
+from django.core.mail import EmailMessage, EmailMultiAlternatives
+from django.test import override_settings
+
+from coalition.core.ses_backend import SESEmailBackend
+
+
+def make_client_error(code: str = "MessageRejected") -> ClientError:
+    """Build a realistic SES API error."""
+    return ClientError(
+        {"Error": {"Code": code, "Message": "Email address is not verified."}},
+        "SendEmail",
+    )
+
+
+class TestSESEmailBackend:
+    """Test the SESEmailBackend class"""
+
+    @staticmethod
+    def make_backend(**kwargs: Any) -> tuple[SESEmailBackend, MagicMock]:
+        """Return a backend wired to a mock SES client."""
+        backend = SESEmailBackend(**kwargs)
+        client = MagicMock()
+        client.send_email.return_value = {"MessageId": "0100-abc"}
+        backend._client = client
+        return backend, client
+
+    def test_send_empty_messages_returns_zero_without_calling_ses(self) -> None:
+        backend, client = self.make_backend()
+
+        assert backend.send_messages([]) == 0
+        client.send_email.assert_not_called()
+
+    def test_sends_raw_mime_with_subject_and_body(self) -> None:
+        backend, client = self.make_backend()
+        message = EmailMessage(
+            "Verify your endorsement",
+            "Click the link",
+            "from@landandbay.org",
+            ["to@example.com"],
+        )
+
+        assert backend.send_messages([message]) == 1
+
+        request = client.send_email.call_args.kwargs
+        raw = request["Content"]["Raw"]["Data"].decode()
+        assert "Verify your endorsement" in raw
+        assert "Click the link" in raw
+        assert request["FromEmailAddress"] == "from@landandbay.org"
+
+    def test_destination_carries_every_recipient_including_bcc(self) -> None:
+        """Bcc recipients must be delivered without appearing in the headers."""
+        backend, client = self.make_backend()
+        message = EmailMessage(
+            "Subject",
+            "Body",
+            "from@landandbay.org",
+            ["to@example.com"],
+            bcc=["hidden@example.com"],
+            cc=["cc@example.com"],
+        )
+
+        backend.send_messages([message])
+
+        request = client.send_email.call_args.kwargs
+        assert set(request["Destination"]["ToAddresses"]) == {
+            "to@example.com",
+            "cc@example.com",
+            "hidden@example.com",
+        }
+        raw = request["Content"]["Raw"]["Data"].decode()
+        assert "hidden@example.com" not in raw
+
+    def test_sends_html_alternative(self) -> None:
+        backend, client = self.make_backend()
+        message = EmailMultiAlternatives(
+            "Subject",
+            "Plain body",
+            "from@landandbay.org",
+            ["to@example.com"],
+        )
+        message.attach_alternative("<p>HTML body</p>", "text/html")
+
+        backend.send_messages([message])
+
+        raw = client.send_email.call_args.kwargs["Content"]["Raw"]["Data"].decode()
+        assert "Plain body" in raw
+        assert "<p>HTML body</p>" in raw
+
+    def test_returns_count_of_messages_sent(self) -> None:
+        backend, client = self.make_backend()
+        messages = [
+            EmailMessage("A", "1", "from@landandbay.org", ["a@example.com"]),
+            EmailMessage("B", "2", "from@landandbay.org", ["b@example.com"]),
+        ]
+
+        assert backend.send_messages(messages) == 2
+        assert client.send_email.call_count == 2
+
+    def test_skips_message_with_no_recipients(self) -> None:
+        backend, client = self.make_backend()
+        message = EmailMessage("Subject", "Body", "from@landandbay.org", [])
+
+        assert backend.send_messages([message]) == 0
+        client.send_email.assert_not_called()
+
+    @override_settings(SES_CONFIGURATION_SET="landandbay-config-set")
+    def test_includes_configuration_set_when_configured(self) -> None:
+        backend, client = self.make_backend()
+        message = EmailMessage("S", "B", "from@landandbay.org", ["to@example.com"])
+
+        backend.send_messages([message])
+
+        request = client.send_email.call_args.kwargs
+        assert request["ConfigurationSetName"] == "landandbay-config-set"
+
+    @override_settings(SES_CONFIGURATION_SET="")
+    def test_omits_configuration_set_when_not_configured(self) -> None:
+        backend, client = self.make_backend()
+        message = EmailMessage("S", "B", "from@landandbay.org", ["to@example.com"])
+
+        backend.send_messages([message])
+
+        assert "ConfigurationSetName" not in client.send_email.call_args.kwargs
+
+    def test_ses_rejection_raises_when_not_fail_silently(self) -> None:
+        """A rejected send must surface, never be reported as delivered."""
+        backend, client = self.make_backend(fail_silently=False)
+        client.send_email.side_effect = make_client_error()
+        message = EmailMessage("S", "B", "from@landandbay.org", ["to@example.com"])
+
+        with pytest.raises(ClientError):
+            backend.send_messages([message])
+
+    def test_unreachable_endpoint_raises_when_not_fail_silently(self) -> None:
+        """No network path to SES must fail loudly rather than look successful."""
+        backend, client = self.make_backend(fail_silently=False)
+        client.send_email.side_effect = EndpointConnectionError(
+            endpoint_url="https://email.us-east-1.amazonaws.com/",
+        )
+        message = EmailMessage("S", "B", "from@landandbay.org", ["to@example.com"])
+
+        with pytest.raises(EndpointConnectionError):
+            backend.send_messages([message])
+
+    def test_ses_rejection_returns_zero_when_fail_silently(self) -> None:
+        backend, client = self.make_backend(fail_silently=True)
+        client.send_email.side_effect = make_client_error()
+        message = EmailMessage("S", "B", "from@landandbay.org", ["to@example.com"])
+
+        assert backend.send_messages([message]) == 0
+
+    def test_failure_of_one_message_does_not_hide_the_rest(self) -> None:
+        backend, client = self.make_backend(fail_silently=True)
+        client.send_email.side_effect = [
+            {"MessageId": "0100-ok"},
+            make_client_error(),
+        ]
+        messages = [
+            EmailMessage("A", "1", "from@landandbay.org", ["a@example.com"]),
+            EmailMessage("B", "2", "from@landandbay.org", ["b@example.com"]),
+        ]
+
+        assert backend.send_messages(messages) == 1
+
+    def test_reuses_one_client_across_messages(self) -> None:
+        messages = [
+            EmailMessage("A", "1", "from@landandbay.org", ["a@example.com"]),
+            EmailMessage("B", "2", "from@landandbay.org", ["b@example.com"]),
+        ]
+
+        with patch("coalition.core.ses_backend.boto3.client") as mock_client:
+            backend = SESEmailBackend()
+            backend.send_messages(messages)
+            backend.send_messages(messages)
+
+        assert mock_client.call_count == 1
+
+    def test_client_uses_sesv2_with_bounded_timeouts(self) -> None:
+        """Every outbound call needs an explicit timeout so Lambda cannot hang."""
+        with patch("coalition.core.ses_backend.boto3.client") as mock_client:
+            backend = SESEmailBackend()
+            backend.send_messages(
+                [EmailMessage("S", "B", "from@landandbay.org", ["to@example.com"])],
+            )
+
+        (service,) = mock_client.call_args.args
+        assert service == "sesv2"
+        config = mock_client.call_args.kwargs["config"]
+        assert config.connect_timeout > 0
+        assert config.read_timeout > 0

--- a/backend/coalition/core/tests/test_ses_backend.py
+++ b/backend/coalition/core/tests/test_ses_backend.py
@@ -185,7 +185,7 @@ class TestSESEmailBackend:
         assert mock_client.call_count == 1
 
     def test_client_uses_sesv2_with_bounded_timeouts(self) -> None:
-        """Every outbound call needs an explicit timeout so Lambda cannot hang."""
+        """Two sequential sends must leave time for the transaction to commit."""
         with patch("coalition.core.ses_backend.boto3.client") as mock_client:
             backend = SESEmailBackend()
             backend.send_messages(
@@ -195,5 +195,6 @@ class TestSESEmailBackend:
         (service,) = mock_client.call_args.args
         assert service == "sesv2"
         config = mock_client.call_args.kwargs["config"]
-        assert config.connect_timeout > 0
-        assert config.read_timeout > 0
+        assert config.retries["total_max_attempts"] == 1
+        assert "max_attempts" not in config.retries
+        assert config.connect_timeout + config.read_timeout < 10

--- a/backend/coalition/endorsements/email_service.py
+++ b/backend/coalition/endorsements/email_service.py
@@ -96,8 +96,7 @@ class EndorsementEmailService:
         Returns True if the message was accepted for delivery.
         """
         verification_url = (
-            f"{settings.SITE_URL}/verify-endorsement/"
-            f"{endorsement.verification_token}/"
+            f"{settings.SITE_URL}/verify-endorsement/{endorsement.verification_token}/"
         )
         delivered = _deliver(
             _OutboundEmail(

--- a/backend/coalition/endorsements/email_service.py
+++ b/backend/coalition/endorsements/email_service.py
@@ -3,11 +3,11 @@ Email service for endorsement verification and notifications
 """
 
 import logging
-from smtplib import SMTPException
+from dataclasses import dataclass
+from typing import Any
 
 from django.conf import settings
 from django.core.mail import send_mail
-from django.template.exceptions import TemplateDoesNotExist
 from django.template.loader import render_to_string
 from django.utils import timezone
 
@@ -15,249 +15,164 @@ from .models import Endorsement
 
 logger = logging.getLogger(__name__)
 
+# Distinctive token matched by the CloudWatch metric filter behind the
+# endorsement-email alarm. Changing it requires updating
+# terraform/modules/monitoring/main.tf.
+DELIVERY_FAILURE_MARKER = "EMAIL_DELIVERY_FAILED"
+
+
+@dataclass(frozen=True)
+class _OutboundEmail:
+    """One message to render and send.
+
+    ``template_base`` names the pair of templates to render: ``<base>.txt``
+    for the plain-text body and ``<base>.html`` for the HTML alternative.
+    """
+
+    subject: str
+    template_base: str
+    context: dict[str, Any]
+    recipients: list[str]
+    description: str
+
+
+def _deliver(email: _OutboundEmail) -> bool:
+    """Render and send one message, reporting failure rather than raising.
+
+    Callers run inside ``transaction.atomic``: letting a transport error
+    propagate would roll back the endorsement the user just submitted, so a
+    broken mail path would destroy their submission instead of merely
+    delaying their verification link. Failures are logged with a traceback
+    and the delivery-failure marker so they still page an operator.
+    """
+    try:
+        plain_message = render_to_string(f"{email.template_base}.txt", email.context)
+        html_message = render_to_string(f"{email.template_base}.html", email.context)
+        sent_count = send_mail(
+            subject=email.subject,
+            message=plain_message,
+            from_email=settings.DEFAULT_FROM_EMAIL,
+            recipient_list=email.recipients,
+            html_message=html_message,
+            fail_silently=False,
+        )
+    except Exception:
+        logger.exception(
+            "%s: could not send %s",
+            DELIVERY_FAILURE_MARKER,
+            email.description,
+        )
+        return False
+
+    if not sent_count:
+        logger.error(
+            "%s: mail backend accepted no recipients for %s",
+            DELIVERY_FAILURE_MARKER,
+            email.description,
+        )
+        return False
+
+    logger.info("Sent %s", email.description)
+    return True
+
+
+def _admin_notification_recipients() -> list[str]:
+    """Resolve configured admin addresses, tolerating a comma-separated string."""
+    configured = getattr(settings, "ADMIN_NOTIFICATION_EMAILS", "")
+    if isinstance(configured, str):
+        return [address.strip() for address in configured.split(",") if address.strip()]
+    if configured:
+        return list(configured)
+    return [address for _name, address in getattr(settings, "ADMINS", [])]
+
 
 class EndorsementEmailService:
     """Service for sending endorsement-related emails"""
 
     @staticmethod
     def send_verification_email(endorsement: Endorsement) -> bool:
+        """Send email verification to the stakeholder.
+
+        Returns True if the message was accepted for delivery.
         """
-        Send email verification to stakeholder
-        Returns True if email was sent successfully
-        """
-        try:
-            # Generate verification URL
-            verification_url = (
-                f"{settings.SITE_URL}/verify-endorsement/"
-                f"{endorsement.verification_token}/"
-            )
+        verification_url = (
+            f"{settings.SITE_URL}/verify-endorsement/"
+            f"{endorsement.verification_token}/"
+        )
+        delivered = _deliver(
+            _OutboundEmail(
+                subject=(
+                    f"Please verify your endorsement for {endorsement.campaign.title}"
+                ),
+                template_base="emails/endorsement_verification",
+                context={
+                    "endorsement": endorsement,
+                    "stakeholder": endorsement.stakeholder,
+                    "campaign": endorsement.campaign,
+                    "verification_url": verification_url,
+                    "site_url": settings.SITE_URL,
+                    "organization_name": settings.ORGANIZATION_NAME,
+                },
+                recipients=[endorsement.stakeholder.email],
+                description=f"verification email for endorsement {endorsement.id}",
+            ),
+        )
 
-            # Email context
-            context = {
-                "endorsement": endorsement,
-                "stakeholder": endorsement.stakeholder,
-                "campaign": endorsement.campaign,
-                "verification_url": verification_url,
-                "site_url": settings.SITE_URL,
-                "organization_name": settings.ORGANIZATION_NAME,
-            }
+        if delivered:
+            endorsement.verification_sent_at = timezone.now()
+            endorsement.save(update_fields=["verification_sent_at"])
 
-            # Render email content
-            subject = f"Please verify your endorsement for {endorsement.campaign.title}"
-
-            # HTML email content
-            html_message = render_to_string(
-                "emails/endorsement_verification.html",
-                context,
-            )
-
-            # Plain text fallback
-            plain_message = render_to_string(
-                "emails/endorsement_verification.txt",
-                context,
-            )
-
-            # Send email
-            success = send_mail(
-                subject=subject,
-                message=plain_message,
-                from_email=settings.DEFAULT_FROM_EMAIL,
-                recipient_list=[endorsement.stakeholder.email],
-                html_message=html_message,
-                fail_silently=False,
-            )
-
-            if success:
-                # Update verification sent timestamp
-                endorsement.verification_sent_at = timezone.now()
-                endorsement.save(update_fields=["verification_sent_at"])
-
-                logger.info(
-                    f"Verification email sent to {endorsement.stakeholder.email} "
-                    f"for endorsement {endorsement.id}",
-                )
-                return True
-            else:
-                logger.error(
-                    f"Failed to send verification email for endorsement "
-                    f"{endorsement.id}",
-                )
-                return False
-
-        except TemplateDoesNotExist as e:
-            logger.error(
-                f"Email template not found for endorsement {endorsement.id}: {str(e)}",
-            )
-            return False
-        except SMTPException as e:
-            logger.error(
-                f"SMTP error sending verification email for endorsement "
-                f"{endorsement.id}: {str(e)}",
-            )
-            return False
-        except (AttributeError, KeyError) as e:
-            logger.error(
-                f"Configuration error sending verification email for endorsement "
-                f"{endorsement.id}: {str(e)}",
-            )
-            return False
+        return delivered
 
     @staticmethod
     def send_admin_notification(endorsement: Endorsement) -> bool:
-        """
-        Send notification to admins about new endorsement requiring review
-        Returns True if email was sent successfully
-        """
-        try:
-            # Get admin emails from settings or use a default
-            admin_emails = getattr(settings, "ADMIN_NOTIFICATION_EMAILS", "")
-            if isinstance(admin_emails, str):
-                admin_emails = [
-                    email.strip() for email in admin_emails.split(",") if email.strip()
-                ]
+        """Notify admins that a new endorsement needs review."""
+        recipients = _admin_notification_recipients()
+        if not recipients:
+            logger.warning("No admin emails configured for endorsement notifications")
+            return False
 
-            if not admin_emails and hasattr(settings, "ADMINS"):
-                admin_emails = [email for name, email in settings.ADMINS]
-
-            if not admin_emails:
-                logger.warning(
-                    "No admin emails configured for endorsement notifications",
-                )
-                return False
-
-            # Email context
-            context = {
-                "endorsement": endorsement,
-                "stakeholder": endorsement.stakeholder,
-                "campaign": endorsement.campaign,
-                "admin_url": (
-                    f"{settings.API_URL}/admin/endorsements/endorsement/"
-                    f"{endorsement.id}/change/"
+        return _deliver(
+            _OutboundEmail(
+                subject=(
+                    f"New endorsement requires review: {endorsement.campaign.title}"
                 ),
-                "organization_name": settings.ORGANIZATION_NAME,
-            }
-
-            # Render email content
-            subject = f"New endorsement requires review: {endorsement.campaign.title}"
-
-            # HTML email content
-            html_message = render_to_string(
-                "emails/admin_endorsement_notification.html",
-                context,
-            )
-
-            # Plain text fallback
-            plain_message = render_to_string(
-                "emails/admin_endorsement_notification.txt",
-                context,
-            )
-
-            # Send email to all admins
-            success = send_mail(
-                subject=subject,
-                message=plain_message,
-                from_email=settings.DEFAULT_FROM_EMAIL,
-                recipient_list=admin_emails,
-                html_message=html_message,
-                fail_silently=False,
-            )
-
-            if success:
-                logger.info(f"Admin notification sent for endorsement {endorsement.id}")
-                return True
-            else:
-                logger.error(
-                    f"Failed to send admin notification for endorsement "
-                    f"{endorsement.id}",
-                )
-                return False
-
-        except TemplateDoesNotExist as e:
-            logger.error(
-                f"Email template not found for admin notification "
-                f"{endorsement.id}: {str(e)}",
-            )
-            return False
-        except SMTPException as e:
-            logger.error(
-                f"SMTP error sending admin notification for endorsement "
-                f"{endorsement.id}: {str(e)}",
-            )
-            return False
-        except (AttributeError, KeyError) as e:
-            logger.error(
-                f"Configuration error sending admin notification for endorsement "
-                f"{endorsement.id}: {str(e)}",
-            )
-            return False
+                template_base="emails/admin_endorsement_notification",
+                context={
+                    "endorsement": endorsement,
+                    "stakeholder": endorsement.stakeholder,
+                    "campaign": endorsement.campaign,
+                    "admin_url": (
+                        f"{settings.API_URL}/admin/endorsements/endorsement/"
+                        f"{endorsement.id}/change/"
+                    ),
+                    "organization_name": settings.ORGANIZATION_NAME,
+                },
+                recipients=recipients,
+                description=f"admin notification for endorsement {endorsement.id}",
+            ),
+        )
 
     @staticmethod
     def send_confirmation_email(endorsement: Endorsement) -> bool:
-        """
-        Send confirmation email to stakeholder when endorsement is approved
-        Returns True if email was sent successfully
-        """
-        try:
-            # Email context
-            context = {
-                "endorsement": endorsement,
-                "stakeholder": endorsement.stakeholder,
-                "campaign": endorsement.campaign,
-                "campaign_url": (
-                    f"{settings.SITE_URL}/campaigns/{endorsement.campaign.id}/"
+        """Confirm to the stakeholder that their endorsement was approved."""
+        return _deliver(
+            _OutboundEmail(
+                subject=(
+                    f"Your endorsement for {endorsement.campaign.title} "
+                    "has been approved"
                 ),
-                "organization_name": settings.ORGANIZATION_NAME,
-            }
-
-            # Render email content
-            subject = (
-                f"Your endorsement for {endorsement.campaign.title} has been approved"
-            )
-
-            # HTML email content
-            html_message = render_to_string("emails/endorsement_approved.html", context)
-
-            # Plain text fallback
-            plain_message = render_to_string("emails/endorsement_approved.txt", context)
-
-            # Send email
-            success = send_mail(
-                subject=subject,
-                message=plain_message,
-                from_email=settings.DEFAULT_FROM_EMAIL,
-                recipient_list=[endorsement.stakeholder.email],
-                html_message=html_message,
-                fail_silently=False,
-            )
-
-            if success:
-                logger.info(
-                    f"Approval confirmation sent to {endorsement.stakeholder.email} "
-                    f"for endorsement {endorsement.id}",
-                )
-                return True
-            else:
-                logger.error(
-                    f"Failed to send approval confirmation for endorsement "
-                    f"{endorsement.id}",
-                )
-                return False
-
-        except TemplateDoesNotExist as e:
-            logger.error(
-                f"Email template not found for approval confirmation "
-                f"{endorsement.id}: {str(e)}",
-            )
-            return False
-        except SMTPException as e:
-            logger.error(
-                f"SMTP error sending approval confirmation for endorsement "
-                f"{endorsement.id}: {str(e)}",
-            )
-            return False
-        except (AttributeError, KeyError) as e:
-            logger.error(
-                f"Configuration error sending approval confirmation for endorsement "
-                f"{endorsement.id}: {str(e)}",
-            )
-            return False
+                template_base="emails/endorsement_approved",
+                context={
+                    "endorsement": endorsement,
+                    "stakeholder": endorsement.stakeholder,
+                    "campaign": endorsement.campaign,
+                    "campaign_url": (
+                        f"{settings.SITE_URL}/campaigns/{endorsement.campaign.id}/"
+                    ),
+                    "organization_name": settings.ORGANIZATION_NAME,
+                },
+                recipients=[endorsement.stakeholder.email],
+                description=f"approval confirmation for endorsement {endorsement.id}",
+            ),
+        )

--- a/backend/coalition/endorsements/tests/test_email_service.py
+++ b/backend/coalition/endorsements/tests/test_email_service.py
@@ -5,7 +5,9 @@ Tests for endorsement email service functionality.
 from smtplib import SMTPException
 from unittest.mock import Mock, patch
 
+from botocore.exceptions import ClientError
 from django.core import mail
+from django.core.exceptions import ImproperlyConfigured
 from django.template.exceptions import TemplateDoesNotExist
 
 from coalition.campaigns.models import PolicyCampaign
@@ -124,3 +126,112 @@ class EndorsementEmailServiceTest(BaseTestCase):
         email = mail.outbox[0]
         assert "has been approved" in email.subject.lower()
         assert self.stakeholder.email in email.to
+
+
+def ses_rejection() -> ClientError:
+    """The error the SES API raises for an unverified or rejected recipient."""
+    return ClientError(
+        {"Error": {"Code": "MessageRejected", "Message": "not verified"}},
+        "SendEmail",
+    )
+
+
+class EndorsementEmailFailureContainmentTest(BaseTestCase):
+    """Email transport failures must be reported, not propagated.
+
+    ``create_endorsement`` sends these emails inside ``transaction.atomic``.
+    An exception escaping the service would roll back the stakeholder and
+    endorsement the user just submitted, so a broken mail path would silently
+    destroy their submission. The service therefore converts every transport
+    failure into ``False`` plus a logged error.
+    """
+
+    def setUp(self) -> None:
+        super().setUp()
+        self.stakeholder = self.create_stakeholder(email="test@example.com")
+        self.campaign = PolicyCampaign.objects.create(
+            name="test-campaign",
+            title="Test Campaign",
+            summary="Test summary",
+        )
+        self.endorsement = Endorsement.objects.create(
+            stakeholder=self.stakeholder,
+            campaign=self.campaign,
+            statement="Test statement",
+        )
+
+    @patch("coalition.endorsements.email_service.send_mail")
+    def test_verification_email_contains_ses_rejection(
+        self,
+        mock_send_mail: Mock,
+    ) -> None:
+        mock_send_mail.side_effect = ses_rejection()
+
+        sent = EndorsementEmailService.send_verification_email(self.endorsement)
+
+        assert sent is False
+
+    @patch("coalition.endorsements.email_service.send_mail")
+    def test_verification_email_contains_misconfiguration(
+        self,
+        mock_send_mail: Mock,
+    ) -> None:
+        mock_send_mail.side_effect = ImproperlyConfigured("EMAIL_HOST missing")
+
+        sent = EndorsementEmailService.send_verification_email(self.endorsement)
+
+        assert sent is False
+
+    @patch("coalition.endorsements.email_service.send_mail")
+    def test_admin_notification_contains_ses_rejection(
+        self,
+        mock_send_mail: Mock,
+    ) -> None:
+        mock_send_mail.side_effect = ses_rejection()
+
+        with self.settings(ADMIN_NOTIFICATION_EMAILS=["admin@example.com"]):
+            result = EndorsementEmailService.send_admin_notification(self.endorsement)
+
+        assert result is False
+
+    @patch("coalition.endorsements.email_service.send_mail")
+    def test_confirmation_email_contains_ses_rejection(
+        self,
+        mock_send_mail: Mock,
+    ) -> None:
+        mock_send_mail.side_effect = ses_rejection()
+
+        sent = EndorsementEmailService.send_confirmation_email(self.endorsement)
+
+        assert sent is False
+
+    @patch("coalition.endorsements.email_service.send_mail")
+    def test_failure_is_logged_with_traceback_and_recipient(
+        self,
+        mock_send_mail: Mock,
+    ) -> None:
+        """Containment only stays safe if the failure is loud in the logs."""
+        mock_send_mail.side_effect = ses_rejection()
+
+        with self.assertLogs(
+            "coalition.endorsements.email_service",
+            level="ERROR",
+        ) as captured:
+            EndorsementEmailService.send_verification_email(self.endorsement)
+
+        record = captured.records[0]
+        assert record.exc_info is not None, "expected traceback for alarm triage"
+        assert str(self.endorsement.id) in record.getMessage()
+
+    @patch("coalition.endorsements.email_service.send_mail")
+    def test_failed_verification_does_not_record_a_sent_timestamp(
+        self,
+        mock_send_mail: Mock,
+    ) -> None:
+        """A resend must remain possible after a failure."""
+        mock_send_mail.side_effect = ses_rejection()
+
+        EndorsementEmailService.send_verification_email(self.endorsement)
+
+        self.endorsement.refresh_from_db()
+        assert self.endorsement.verification_sent_at is None

--- a/backend/scripts/configure_zappa.py
+++ b/backend/scripts/configure_zappa.py
@@ -406,16 +406,21 @@ def configure_zappa_settings(output_path: Path | None = None) -> None:
         else:
             staging_docker_image = "public.ecr.aws/lambda/python:3.13"
 
-        staging_environment_variables = with_stage_cloudfront_domain(
-            {
-                "ENVIRONMENT": "staging",
-                "DEBUG": "false",
-                "DATABASE_NAME": staging_db_name,
-                "AWS_STORAGE_BUCKET_NAME": staging_assets_bucket,
-            },
+        staging_environment_variables = with_email_settings(
+            with_stage_cloudfront_domain(
+                {
+                    "ENVIRONMENT": "staging",
+                    "DEBUG": "false",
+                    "DATABASE_NAME": staging_db_name,
+                    "AWS_STORAGE_BUCKET_NAME": staging_assets_bucket,
+                },
+                deployment_environment,
+                STAGING_STAGE_NAMES,
+                cloudfront_domain,
+            ),
             deployment_environment,
             STAGING_STAGE_NAMES,
-            cloudfront_domain,
+            email_settings,
         )
 
         settings["staging"] = {

--- a/backend/scripts/configure_zappa.py
+++ b/backend/scripts/configure_zappa.py
@@ -121,14 +121,15 @@ def validate_email_settings(
     deployment_environment: str,
     email_settings: dict[str, str],
 ) -> None:
-    """Refuse to deploy prod with mail that would be sent but unusable.
+    """Refuse to deploy a non-debug stage with unusable email settings.
 
     Without ``SITE_URL`` Django builds verification links against
     ``http://localhost:3000``, and without ``DEFAULT_FROM_EMAIL`` it sends
     from an address SES will reject. Both fail as quietly as a missing
     network path, so they are caught here instead.
     """
-    if deployment_environment not in PROD_STAGE_NAMES:
+    email_delivery_stage_names = PROD_STAGE_NAMES | STAGING_STAGE_NAMES
+    if deployment_environment not in email_delivery_stage_names:
         return
 
     missing = [
@@ -138,7 +139,8 @@ def validate_email_settings(
     ]
     if missing:
         raise RuntimeError(
-            f"{' and '.join(missing)} must be set when deploying prod so "
+            f"{' and '.join(missing)} must be set when deploying "
+            f"{deployment_environment} so "
             "endorsement verification emails carry a reachable link from an "
             "address SES accepts.",
         )

--- a/backend/scripts/configure_zappa.py
+++ b/backend/scripts/configure_zappa.py
@@ -86,6 +86,64 @@ def with_location_place_index(
     return environment_variables
 
 
+# Django reads these at startup; each falls back to a local-development
+# default that is wrong (and silently so) in a deployed environment.
+EMAIL_SETTING_NAMES = (
+    "SITE_URL",
+    "API_URL",
+    "DEFAULT_FROM_EMAIL",
+    "ADMIN_NOTIFICATION_EMAILS",
+    "SES_CONFIGURATION_SET",
+)
+
+
+def collect_email_settings() -> dict[str, str]:
+    """Read the configured email env vars, dropping the unset ones."""
+    configured = {
+        name: get_env_or_default(name).strip() for name in EMAIL_SETTING_NAMES
+    }
+    return {name: value for name, value in configured.items() if value}
+
+
+def with_email_settings(
+    environment_variables: dict[str, str],
+    deployment_environment: str,
+    stage_names: set[str],
+    email_settings: dict[str, str],
+) -> dict[str, str]:
+    """Return the env vars with email settings added for the selected stage."""
+    if deployment_environment in stage_names:
+        return {**environment_variables, **email_settings}
+    return environment_variables
+
+
+def validate_email_settings(
+    deployment_environment: str,
+    email_settings: dict[str, str],
+) -> None:
+    """Refuse to deploy prod with mail that would be sent but unusable.
+
+    Without ``SITE_URL`` Django builds verification links against
+    ``http://localhost:3000``, and without ``DEFAULT_FROM_EMAIL`` it sends
+    from an address SES will reject. Both fail as quietly as a missing
+    network path, so they are caught here instead.
+    """
+    if deployment_environment not in PROD_STAGE_NAMES:
+        return
+
+    missing = [
+        name
+        for name in ("SITE_URL", "DEFAULT_FROM_EMAIL")
+        if name not in email_settings
+    ]
+    if missing:
+        raise RuntimeError(
+            f"{' and '.join(missing)} must be set when deploying prod so "
+            "endorsement verification emails carry a reachable link from an "
+            "address SES accepts.",
+        )
+
+
 def configure_zappa_settings(output_path: Path | None = None) -> None:
     """Generate zappa_settings.json from environment variables."""
 
@@ -127,6 +185,8 @@ def configure_zappa_settings(output_path: Path | None = None) -> None:
         cloudfront_domain,
         active_stage_names,
     )
+    email_settings = collect_email_settings()
+    validate_email_settings(deployment_environment, email_settings)
     dev_assets_bucket = get_stage_value(
         deployment_environment,
         DEV_STAGE_NAMES,
@@ -200,27 +260,37 @@ def configure_zappa_settings(output_path: Path | None = None) -> None:
         dev_docker_image = "public.ecr.aws/lambda/python:3.13"
         production_docker_image = "public.ecr.aws/lambda/python:3.13"
 
-    dev_environment_variables = with_stage_cloudfront_domain(
-        {
-            "ENVIRONMENT": "dev",
-            "DEBUG": "true",
-            "DATABASE_NAME": dev_db_name,
-            "AWS_STORAGE_BUCKET_NAME": dev_assets_bucket,
-        },
+    dev_environment_variables = with_email_settings(
+        with_stage_cloudfront_domain(
+            {
+                "ENVIRONMENT": "dev",
+                "DEBUG": "true",
+                "DATABASE_NAME": dev_db_name,
+                "AWS_STORAGE_BUCKET_NAME": dev_assets_bucket,
+            },
+            deployment_environment,
+            DEV_STAGE_NAMES,
+            cloudfront_domain,
+        ),
         deployment_environment,
         DEV_STAGE_NAMES,
-        cloudfront_domain,
+        email_settings,
     )
-    production_environment_variables = with_stage_cloudfront_domain(
-        {
-            "ENVIRONMENT": "production",
-            "DEBUG": "false",
-            "DATABASE_NAME": production_db_name,
-            "AWS_STORAGE_BUCKET_NAME": production_assets_bucket,
-        },
+    production_environment_variables = with_email_settings(
+        with_stage_cloudfront_domain(
+            {
+                "ENVIRONMENT": "production",
+                "DEBUG": "false",
+                "DATABASE_NAME": production_db_name,
+                "AWS_STORAGE_BUCKET_NAME": production_assets_bucket,
+            },
+            deployment_environment,
+            PROD_STAGE_NAMES,
+            cloudfront_domain,
+        ),
         deployment_environment,
         PROD_STAGE_NAMES,
-        cloudfront_domain,
+        email_settings,
     )
 
     # Build the configuration

--- a/backend/scripts/tests/test_configure_zappa.py
+++ b/backend/scripts/tests/test_configure_zappa.py
@@ -332,6 +332,8 @@ class TestDeploymentEnvironmentValidation:
                 "ENABLE_STAGING": "true",
                 "DEPLOYMENT_ENVIRONMENT": "staging",
                 "AWS_STORAGE_BUCKET_NAME": "coalition-staging-assets-example",
+                "SITE_URL": "https://staging.example.org",
+                "DEFAULT_FROM_EMAIL": "admin@example.org",
             },
         )
         assert (
@@ -575,3 +577,26 @@ class TestEmailConfiguration:
             staging_environment[name] == configured_value
             for name, configured_value in email_settings.items()
         )
+
+    @pytest.mark.parametrize("missing_setting", ["SITE_URL", "DEFAULT_FROM_EMAIL"])
+    def test_staging_requires_email_settings(
+        self,
+        tmp_path: Path,
+        missing_setting: str,
+    ) -> None:
+        """Staging sends real mail and must reject local-development defaults."""
+        email_settings = {
+            "SITE_URL": "https://staging.example.org",
+            "DEFAULT_FROM_EMAIL": "admin@example.org",
+        }
+        del email_settings[missing_setting]
+
+        with pytest.raises(RuntimeError, match=missing_setting):
+            _generate_settings(
+                tmp_path,
+                {
+                    "ENABLE_STAGING": "true",
+                    "DEPLOYMENT_ENVIRONMENT": "staging",
+                    **email_settings,
+                },
+            )

--- a/backend/scripts/tests/test_configure_zappa.py
+++ b/backend/scripts/tests/test_configure_zappa.py
@@ -550,3 +550,28 @@ class TestEmailConfiguration:
         settings = _generate_settings(tmp_path, {"DEPLOYMENT_ENVIRONMENT": "dev"})
 
         assert "SITE_URL" not in settings["dev"]["environment_variables"]
+
+    def test_selected_staging_receives_email_settings(self, tmp_path: Path) -> None:
+        """A generated non-debug staging Lambda must not use local email defaults."""
+        email_settings = {
+            "SITE_URL": "https://staging.example.org",
+            "API_URL": "https://api.staging.example.org",
+            "DEFAULT_FROM_EMAIL": "admin@example.org",
+            "ADMIN_NOTIFICATION_EMAILS": "ops@example.org",
+            "SES_CONFIGURATION_SET": "example-staging",
+        }
+
+        settings = _generate_settings(
+            tmp_path,
+            {
+                "ENABLE_STAGING": "true",
+                "DEPLOYMENT_ENVIRONMENT": "staging",
+                **email_settings,
+            },
+        )
+
+        staging_environment = settings["staging"]["environment_variables"]
+        assert all(
+            staging_environment[name] == configured_value
+            for name, configured_value in email_settings.items()
+        )

--- a/backend/scripts/tests/test_configure_zappa.py
+++ b/backend/scripts/tests/test_configure_zappa.py
@@ -151,6 +151,8 @@ class TestAssetConfiguration:
                 "DEPLOYMENT_ENVIRONMENT": "prod",
                 "AWS_STORAGE_BUCKET_NAME": "coalition-production-assets-example",
                 "CLOUDFRONT_DOMAIN": "media.example.cloudfront.net",
+                "SITE_URL": "https://example.org",
+                "DEFAULT_FROM_EMAIL": "admin@example.org",
             },
         )
         assert (
@@ -169,6 +171,8 @@ class TestAssetConfiguration:
                 "DEPLOYMENT_ENVIRONMENT": "prod",
                 "AWS_STORAGE_BUCKET_NAME": "production-assets",
                 "CLOUDFRONT_DOMAIN": "media.example.cloudfront.net",
+                "SITE_URL": "https://example.org",
+                "DEFAULT_FROM_EMAIL": "admin@example.org",
             },
         )
         assert (
@@ -464,3 +468,85 @@ class TestStagingGating:
         settings = _generate_settings(tmp_path)
         stage_keys = {k for k in settings if k != "base"}
         assert stage_keys == {"dev", "prod"}
+
+
+class TestEmailConfiguration:
+    """Lambda needs email settings baked in, or mail is wrong rather than absent.
+
+    Django defaults SITE_URL to http://localhost:3000, so a deploy without it
+    sends verification links that no recipient can ever follow. That fails as
+    quietly as an unreachable mail server, so prod deploys must refuse.
+    """
+
+    _prod_env = {
+        "DEPLOYMENT_ENVIRONMENT": "prod",
+        "CLOUDFRONT_DOMAIN": "cdn.example.org",
+        "SITE_URL": "https://landandbay.org",
+        "DEFAULT_FROM_EMAIL": "admin@landandbay.org",
+    }
+
+    def test_prod_receives_site_url_for_verification_links(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        settings = _generate_settings(tmp_path, self._prod_env)
+
+        env = settings["prod"]["environment_variables"]
+        assert env["SITE_URL"] == "https://landandbay.org"
+
+    def test_prod_receives_sender_address(self, tmp_path: Path) -> None:
+        settings = _generate_settings(tmp_path, self._prod_env)
+
+        env = settings["prod"]["environment_variables"]
+        assert env["DEFAULT_FROM_EMAIL"] == "admin@landandbay.org"
+
+    def test_optional_email_settings_are_passed_through(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        settings = _generate_settings(
+            tmp_path,
+            {
+                **self._prod_env,
+                "API_URL": "https://api.landandbay.org",
+                "ADMIN_NOTIFICATION_EMAILS": "ops@landandbay.org",
+                "SES_CONFIGURATION_SET": "landandbay-config-set",
+            },
+        )
+
+        env = settings["prod"]["environment_variables"]
+        assert env["API_URL"] == "https://api.landandbay.org"
+        assert env["ADMIN_NOTIFICATION_EMAILS"] == "ops@landandbay.org"
+        assert env["SES_CONFIGURATION_SET"] == "landandbay-config-set"
+
+    def test_unset_optional_email_settings_are_omitted(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """Empty values must not override Django's own defaults."""
+        settings = _generate_settings(tmp_path, self._prod_env)
+
+        env = settings["prod"]["environment_variables"]
+        assert "ADMIN_NOTIFICATION_EMAILS" not in env
+        assert "SES_CONFIGURATION_SET" not in env
+
+    def test_prod_without_site_url_raises(self, tmp_path: Path) -> None:
+        env = {k: v for k, v in self._prod_env.items() if k != "SITE_URL"}
+
+        with pytest.raises(RuntimeError, match="SITE_URL"):
+            _generate_settings(tmp_path, env)
+
+    def test_prod_without_sender_address_raises(self, tmp_path: Path) -> None:
+        env = {k: v for k, v in self._prod_env.items() if k != "DEFAULT_FROM_EMAIL"}
+
+        with pytest.raises(RuntimeError, match="DEFAULT_FROM_EMAIL"):
+            _generate_settings(tmp_path, env)
+
+    def test_dev_deployment_does_not_require_email_settings(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """Dev logs mail to the console, so it needs no sender or site URL."""
+        settings = _generate_settings(tmp_path, {"DEPLOYMENT_ENVIRONMENT": "dev"})
+
+        assert "SITE_URL" not in settings["dev"]["environment_variables"]

--- a/docs/email-configuration.md
+++ b/docs/email-configuration.md
@@ -159,11 +159,11 @@ The ECS task definition needs to pull these secrets. Add to your task definition
 
 Which backend Django uses is decided in `backend/coalition/core/settings.py` and depends on where the app runs:
 
-| Environment                  | Backend                                        | Transport                       |
-| ---------------------------- | ---------------------------------------------- | ------------------------------- |
-| `DEBUG=True` (local)         | Django's console backend                       | Printed to stdout               |
-| Lambda (`IS_LAMBDA`)         | `coalition.core.ses_backend.SESEmailBackend`   | SES API over a VPC endpoint     |
-| Other deployments            | `coalition.core.email_backend.SafeSMTPBackend` | SES SMTP on port 587            |
+| Environment          | Backend                                        | Transport                   |
+| -------------------- | ---------------------------------------------- | --------------------------- |
+| `DEBUG=True` (local) | Django's console backend                       | Printed to stdout           |
+| Lambda (`IS_LAMBDA`) | `coalition.core.ses_backend.SESEmailBackend`   | SES API over a VPC endpoint |
+| Other deployments    | `coalition.core.email_backend.SafeSMTPBackend` | SES SMTP on port 587        |
 
 Set `EMAIL_BACKEND` explicitly to override the choice.
 
@@ -182,13 +182,13 @@ Location: `backend/coalition/core/ses_backend.py`
 
 Django's defaults for these are local-development values, and a deploy that misses them sends mail that is technically delivered but useless — verification links pointing at `http://localhost:3000`. Prod deploys refuse to proceed without the first two (`backend/scripts/configure_zappa.py`):
 
-| GitHub environment variable | Purpose                                                     |
-| --------------------------- | ----------------------------------------------------------- |
-| `SITE_URL`                  | Base URL for verification links (**required for prod**)       |
+| GitHub environment variable | Purpose                                                          |
+| --------------------------- | ---------------------------------------------------------------- |
+| `SITE_URL`                  | Base URL for verification links (**required for prod**)          |
 | `DEFAULT_FROM_EMAIL`        | Sender address; must pass the SES policy (**required for prod**) |
-| `API_URL`                   | Base URL for admin links in notification emails               |
-| `ADMIN_NOTIFICATION_EMAILS` | Comma-separated recipients for new-endorsement notices        |
-| `SES_CONFIGURATION_SET`     | SES configuration set recording bounces and deliveries        |
+| `API_URL`                   | Base URL for admin links in notification emails                  |
+| `ADMIN_NOTIFICATION_EMAILS` | Comma-separated recipients for new-endorsement notices           |
+| `SES_CONFIGURATION_SET`     | SES configuration set recording bounces and deliveries           |
 
 ### Failure handling and alerting
 

--- a/docs/email-configuration.md
+++ b/docs/email-configuration.md
@@ -157,14 +157,44 @@ The ECS task definition needs to pull these secrets. Add to your task definition
 
 ## Email Backend
 
-The application uses a custom `SafeSMTPBackend` that:
+Which backend Django uses is decided in `backend/coalition/core/settings.py` and depends on where the app runs:
 
-- Attempts to send via SMTP (SES)
-- Falls back to console output if SMTP fails
-- Has shorter timeouts to prevent hanging
-- Logs all email activity for debugging
+| Environment                  | Backend                                        | Transport                       |
+| ---------------------------- | ---------------------------------------------- | ------------------------------- |
+| `DEBUG=True` (local)         | Django's console backend                       | Printed to stdout               |
+| Lambda (`IS_LAMBDA`)         | `coalition.core.ses_backend.SESEmailBackend`   | SES API over a VPC endpoint     |
+| Other deployments            | `coalition.core.email_backend.SafeSMTPBackend` | SES SMTP on port 587            |
 
-Location: `backend/coalition/core/email_backend.py`
+Set `EMAIL_BACKEND` explicitly to override the choice.
+
+**Neither production backend falls back to the console.** A failure that is logged instead of raised looks exactly like a delivered email to every caller, so an outage stays invisible while users wait for verification links that were never sent. Both backends raise instead, and `SafeSMTPBackend` also raises `ImproperlyConfigured` when `EMAIL_HOST` or `EMAIL_PORT` is missing rather than quietly discarding mail. The console fallback exists only under `DEBUG`.
+
+### Sending from Lambda
+
+Lambda runs in private subnets with no NAT gateway and no `0.0.0.0/0` route, so `email-smtp.<region>.amazonaws.com:587` is unreachable — connections simply hang. Two things make delivery work:
+
+- An interface VPC endpoint for `com.amazonaws.<region>.email` (enabled with `enable_ses_endpoint` in the networking module). Its private DNS maps `email.<region>.amazonaws.com` onto the endpoint, so the AWS SDK needs no `endpoint_url` override.
+- `ses:SendEmail` / `ses:SendRawEmail` granted to the Lambda execution role via the SES module's `sender_role_names`, scoped to the verified domain. This replaces static SMTP credentials entirely — there are no access keys to rotate or leak.
+
+Location: `backend/coalition/core/ses_backend.py`
+
+### Required deployment settings
+
+Django's defaults for these are local-development values, and a deploy that misses them sends mail that is technically delivered but useless — verification links pointing at `http://localhost:3000`. Prod deploys refuse to proceed without the first two (`backend/scripts/configure_zappa.py`):
+
+| GitHub environment variable | Purpose                                                     |
+| --------------------------- | ----------------------------------------------------------- |
+| `SITE_URL`                  | Base URL for verification links (**required for prod**)       |
+| `DEFAULT_FROM_EMAIL`        | Sender address; must pass the SES policy (**required for prod**) |
+| `API_URL`                   | Base URL for admin links in notification emails               |
+| `ADMIN_NOTIFICATION_EMAILS` | Comma-separated recipients for new-endorsement notices        |
+| `SES_CONFIGURATION_SET`     | SES configuration set recording bounces and deliveries        |
+
+### Failure handling and alerting
+
+`EndorsementEmailService` sends inside `transaction.atomic()`, so it deliberately converts transport failures into `False` plus a logged error rather than letting them propagate — an exception there would roll back the endorsement the user just submitted and turn a mail outage into silent data loss.
+
+Because the failure is contained, an alarm is what makes it visible. The service logs the marker `EMAIL_DELIVERY_FAILED`, which a CloudWatch metric filter turns into the `EmailDeliveryFailures` metric behind the `<prefix>-email-delivery-failure` alarm (see `terraform/modules/monitoring/main.tf`). The alarm fires on the first failure and notifies the `<prefix>-email-delivery-alerts` SNS topic. Changing the marker string means updating the metric filter too.
 
 ## Testing Email Configuration
 
@@ -204,15 +234,20 @@ python manage.py shell
    - You're in sandbox mode and trying to send to unverified address
    - Solution: Verify the recipient or request production access
 
-2. **"Connection timeout"**
-   - ECS task cannot reach SES endpoint
-   - Solution: Ensure ECS is in public subnet with internet access
+2. **"Connection timeout" or a request that hangs until the Lambda times out**
+   - The task cannot reach the SES endpoint. On Lambda this means the SES interface VPC endpoint is missing: the private subnets have no NAT and no default route, so the connection never completes rather than failing fast.
+   - Solution: set `enable_ses_endpoint = true` for the environment. Confirm with `socket.gethostbyname("email.<region>.amazonaws.com")` from inside the function — it must return a private VPC address, not a public one.
+   - For non-Lambda deployments, ensure the task has internet egress.
 
 3. **"Invalid credentials"**
    - SMTP credentials are incorrect
-   - Solution: Regenerate SMTP credentials in SES console
+   - Solution: Regenerate SMTP credentials in SES console. On Lambda this error should not occur at all — it authenticates with the execution role, so check `sender_role_names` and the `ses:FromAddress` condition instead.
 
-4. **"Rate exceeded"**
+4. **"Email address is not verified" for ordinary users**
+   - The account is still in the SES sandbox, which only permits verified recipients. Sending to your own verified domain succeeds while every real endorser is rejected, so this can look like a partial outage.
+   - Solution: request production access (see "Move Out of Sandbox" above), then confirm with `aws sesv2 get-account --query ProductionAccessEnabled`.
+
+5. **"Rate exceeded"**
    - Sending too many emails too quickly
    - Solution: Implement rate limiting or request higher SES limits
 

--- a/terraform/environments/dev/main.tf
+++ b/terraform/environments/dev/main.tf
@@ -64,6 +64,10 @@ module "networking" {
   create_vpc_endpoints       = var.enable_vpc_endpoints
   enable_single_az_endpoints = true
 
+  # Opt in temporarily through the Dev Cost Control workflow when validating
+  # SES connectivity from the dev VPC.
+  enable_ses_endpoint = var.enable_ses_endpoint
+
   # Nothing here calls the CloudWatch Logs API; Lambda's own logs arrive
   # without it. Saves ~$7.44/mo whenever dev endpoints are switched on.
   enable_logs_endpoint = false

--- a/terraform/environments/dev/main.tf
+++ b/terraform/environments/dev/main.tf
@@ -63,6 +63,10 @@ module "networking" {
   # VPC endpoints for Lambda to reach AWS services (toggle to save costs)
   create_vpc_endpoints       = var.enable_vpc_endpoints
   enable_single_az_endpoints = true
+
+  # Nothing here calls the CloudWatch Logs API; Lambda's own logs arrive
+  # without it. Saves ~$7.44/mo whenever dev endpoints are switched on.
+  enable_logs_endpoint = false
 }
 
 # VPC Peering - dev to shared

--- a/terraform/environments/dev/main.tf
+++ b/terraform/environments/dev/main.tf
@@ -64,10 +64,6 @@ module "networking" {
   create_vpc_endpoints       = var.enable_vpc_endpoints
   enable_single_az_endpoints = true
 
-  # Opt in temporarily through the Dev Cost Control workflow when validating
-  # SES connectivity from the dev VPC.
-  enable_ses_endpoint = var.enable_ses_endpoint
-
   # Nothing here calls the CloudWatch Logs API; Lambda's own logs arrive
   # without it. Saves ~$7.44/mo whenever dev endpoints are switched on.
   enable_logs_endpoint = false

--- a/terraform/environments/dev/variables.tf
+++ b/terraform/environments/dev/variables.tf
@@ -57,12 +57,6 @@ variable "enable_vpc_endpoints" {
   default     = true
 }
 
-variable "enable_ses_endpoint" {
-  description = "Temporarily enable the SES API VPC endpoint for dev connectivity testing"
-  type        = bool
-  default     = false
-}
-
 # Database (in shared account, accessed via peering)
 variable "db_name" {
   description = "Database name in the shared RDS instance (dev database)"

--- a/terraform/environments/dev/variables.tf
+++ b/terraform/environments/dev/variables.tf
@@ -57,6 +57,12 @@ variable "enable_vpc_endpoints" {
   default     = true
 }
 
+variable "enable_ses_endpoint" {
+  description = "Temporarily enable the SES API VPC endpoint for dev connectivity testing"
+  type        = bool
+  default     = false
+}
+
 # Database (in shared account, accessed via peering)
 variable "db_name" {
   description = "Database name in the shared RDS instance (dev database)"

--- a/terraform/environments/prod/main.tf
+++ b/terraform/environments/prod/main.tf
@@ -67,6 +67,10 @@ module "networking" {
   # Prod is the only environment that sends transactional email, and these
   # subnets have no NAT or default route, so SES is only reachable this way.
   enable_ses_endpoint = true
+
+  # Nothing here calls the CloudWatch Logs API; Lambda's own logs arrive
+  # without it. Dropping it pays for the SES endpoint above.
+  enable_logs_endpoint = false
 }
 
 # VPC Peering - prod to shared

--- a/terraform/environments/prod/main.tf
+++ b/terraform/environments/prod/main.tf
@@ -63,6 +63,10 @@ module "networking" {
   # VPC endpoints for Lambda to reach AWS services
   create_vpc_endpoints       = true
   enable_single_az_endpoints = true
+
+  # Prod is the only environment that sends transactional email, and these
+  # subnets have no NAT or default route, so SES is only reachable this way.
+  enable_ses_endpoint = true
 }
 
 # VPC Peering - prod to shared
@@ -184,6 +188,10 @@ module "monitoring" {
   vpc_id              = module.networking.vpc_id
   budget_limit_amount = var.budget_limit_amount
   alert_email         = var.alert_email
+
+  # Email failures are contained so submissions survive; this alarm is what
+  # makes them visible. Zappa names the function <project_name>-<stage>.
+  application_log_group_name = "/aws/lambda/coalition-prod"
 }
 
 # SES Module (Route53 records created separately with shared provider)
@@ -199,6 +207,10 @@ module "ses" {
   dmarc_email            = var.ses_notification_email
   notification_email     = var.ses_notification_email
   enable_notifications   = true
+
+  # Lambda sends through the SES API with its execution role, so it needs no
+  # static SMTP credentials.
+  sender_role_names = [module.zappa.zappa_deployment_role_name]
 }
 
 # Wait for SES domain verification (record is created cross-account below)

--- a/terraform/modules/monitoring/main.tf
+++ b/terraform/modules/monitoring/main.tf
@@ -293,3 +293,68 @@ resource "awscc_ce_anomaly_subscription" "project_anomaly_subscription" {
   # Alert on anomalies with impact >= $5
   threshold = 5
 }
+
+# Email delivery failure alarm
+#
+# The endorsement email service converts transport failures into a logged
+# error rather than an exception, so that a broken mail path never rolls back
+# the submission the user just made. That containment is only safe if someone
+# is told: this alarm is what makes the failure loud.
+resource "aws_cloudwatch_log_metric_filter" "email_delivery_failure" {
+  count = var.application_log_group_name != "" ? 1 : 0
+
+  name           = "${var.prefix}-email-delivery-failure"
+  log_group_name = var.application_log_group_name
+
+  # Marker emitted by coalition.endorsements.email_service.DELIVERY_FAILURE_MARKER
+  pattern = "EMAIL_DELIVERY_FAILED"
+
+  metric_transformation {
+    name          = "EmailDeliveryFailures"
+    namespace     = "${var.prefix}/Application"
+    value         = "1"
+    default_value = "0"
+  }
+}
+
+resource "aws_sns_topic" "email_delivery_alerts" {
+  count = var.application_log_group_name != "" ? 1 : 0
+
+  name = "${var.prefix}-email-delivery-alerts"
+
+  tags = {
+    Name = "${var.prefix}-email-delivery-alerts"
+  }
+}
+
+resource "aws_sns_topic_subscription" "email_delivery_alerts" {
+  count = var.application_log_group_name != "" ? 1 : 0
+
+  topic_arn = aws_sns_topic.email_delivery_alerts[0].arn
+  protocol  = "email"
+  endpoint  = var.alert_email
+}
+
+resource "aws_cloudwatch_metric_alarm" "email_delivery_failure" {
+  count = var.application_log_group_name != "" ? 1 : 0
+
+  alarm_name        = "${var.prefix}-email-delivery-failure"
+  alarm_description = "Outbound email failed to send. Endorsement verification links are not reaching users."
+
+  namespace   = "${var.prefix}/Application"
+  metric_name = aws_cloudwatch_log_metric_filter.email_delivery_failure[0].metric_transformation[0].name
+  statistic   = "Sum"
+  period      = 300
+
+  comparison_operator = "GreaterThanThreshold"
+  threshold           = 0
+  evaluation_periods  = 1
+  treat_missing_data  = "notBreaching"
+
+  alarm_actions = [aws_sns_topic.email_delivery_alerts[0].arn]
+  ok_actions    = [aws_sns_topic.email_delivery_alerts[0].arn]
+
+  tags = {
+    Name = "${var.prefix}-email-delivery-failure"
+  }
+}

--- a/terraform/modules/monitoring/tests/email_delivery_alarm.tftest.hcl
+++ b/terraform/modules/monitoring/tests/email_delivery_alarm.tftest.hcl
@@ -1,0 +1,65 @@
+# Email failures are contained at the call site so a submission is never lost,
+# which means nothing surfaces them to a human unless an alarm does. These
+# tests pin that the alarm exists and fires on the first failure.
+
+mock_provider "aws" {}
+mock_provider "awscc" {}
+mock_provider "random" {}
+
+variables {
+  prefix      = "example"
+  vpc_id      = "vpc-12345678"
+  alert_email = "ops@example.org"
+}
+
+run "no_alarm_without_a_log_group" {
+  command = plan
+
+  assert {
+    condition     = length(aws_cloudwatch_log_metric_filter.email_delivery_failure) == 0
+    error_message = "The metric filter must be opt-in for environments that have no application log group."
+  }
+
+  assert {
+    condition     = length(aws_cloudwatch_metric_alarm.email_delivery_failure) == 0
+    error_message = "The alarm must be opt-in for environments that have no application log group."
+  }
+}
+
+run "alarm_watches_the_application_log_group" {
+  command = plan
+
+  variables {
+    application_log_group_name = "/aws/lambda/example-prod"
+  }
+
+  assert {
+    condition     = aws_cloudwatch_log_metric_filter.email_delivery_failure[0].log_group_name == "/aws/lambda/example-prod"
+    error_message = "The metric filter must read the application log group."
+  }
+
+  assert {
+    condition     = can(regex("EMAIL_DELIVERY_FAILED", aws_cloudwatch_log_metric_filter.email_delivery_failure[0].pattern))
+    error_message = "The filter must match the marker the email service logs; see coalition/endorsements/email_service.py."
+  }
+
+  assert {
+    condition     = aws_cloudwatch_metric_alarm.email_delivery_failure[0].threshold == 0
+    error_message = "A single undelivered verification email is already a user-visible outage."
+  }
+
+  assert {
+    condition     = aws_cloudwatch_metric_alarm.email_delivery_failure[0].comparison_operator == "GreaterThanThreshold"
+    error_message = "The alarm must fire when failures exceed zero."
+  }
+
+  assert {
+    condition     = aws_cloudwatch_metric_alarm.email_delivery_failure[0].treat_missing_data == "notBreaching"
+    error_message = "No log events must read as healthy, not as insufficient data."
+  }
+
+  assert {
+    condition     = length(aws_cloudwatch_metric_alarm.email_delivery_failure[0].alarm_actions) > 0
+    error_message = "The alarm must notify somebody; an alarm with no action is not louder than a log line."
+  }
+}

--- a/terraform/modules/monitoring/variables.tf
+++ b/terraform/modules/monitoring/variables.tf
@@ -19,3 +19,8 @@ variable "alert_email" {
   description = "Email address to receive budget and other alerts"
   type        = string
 }
+variable "application_log_group_name" {
+  description = "CloudWatch log group to watch for email delivery failures (empty disables the alarm)"
+  type        = string
+  default     = ""
+}

--- a/terraform/modules/networking/main.tf
+++ b/terraform/modules/networking/main.tf
@@ -272,7 +272,6 @@ resource "aws_vpc_endpoint" "s3" {
 locals {
   always_on_interface_endpoints = {
     secretsmanager = "com.amazonaws.${var.aws_region}.secretsmanager"
-    logs           = "com.amazonaws.${var.aws_region}.logs"
     geo_places     = "com.amazonaws.${var.aws_region}.geo.places"
   }
 
@@ -283,9 +282,22 @@ locals {
     ses = "com.amazonaws.${var.aws_region}.email"
   } : {}
 
+  # Only needed by code that calls the CloudWatch Logs API itself. Lambda's own
+  # log delivery is performed by the Lambda service outside this VPC, so
+  # function logs keep flowing without it — verified against prod by denying
+  # all traffic through the endpoint and confirming logs still arrived.
+  #
+  # Beware when re-enabling is needed: with the endpoint absent, private DNS no
+  # longer overrides logs.<region>.amazonaws.com, so a Logs API call from these
+  # subnets HANGS until timeout rather than failing fast.
+  logs_interface_endpoint = var.enable_logs_endpoint ? {
+    logs = "com.amazonaws.${var.aws_region}.logs"
+  } : {}
+
   interface_endpoints = merge(
     local.always_on_interface_endpoints,
     local.ses_interface_endpoint,
+    local.logs_interface_endpoint,
   )
 
   endpoint_subnet_ids = (

--- a/terraform/modules/networking/main.tf
+++ b/terraform/modules/networking/main.tf
@@ -270,11 +270,24 @@ resource "aws_vpc_endpoint" "s3" {
 
 # Interface VPC Endpoints - allow Lambda in private subnets to reach AWS services
 locals {
-  interface_endpoints = {
+  always_on_interface_endpoints = {
     secretsmanager = "com.amazonaws.${var.aws_region}.secretsmanager"
     logs           = "com.amazonaws.${var.aws_region}.logs"
     geo_places     = "com.amazonaws.${var.aws_region}.geo.places"
   }
+
+  # The SES API endpoint. Private DNS maps email.<region>.amazonaws.com onto
+  # it, so the AWS SDK reaches SES with no endpoint override. Opt-in because
+  # each interface endpoint bills hourly in every environment that enables it.
+  ses_interface_endpoint = var.enable_ses_endpoint ? {
+    ses = "com.amazonaws.${var.aws_region}.email"
+  } : {}
+
+  interface_endpoints = merge(
+    local.always_on_interface_endpoints,
+    local.ses_interface_endpoint,
+  )
+
   endpoint_subnet_ids = (
     length(local.private_subnet_ids) > 0 && var.enable_single_az_endpoints
     ? [local.private_subnet_ids[0]]

--- a/terraform/modules/networking/tests/logs_endpoint.tftest.hcl
+++ b/terraform/modules/networking/tests/logs_endpoint.tftest.hcl
@@ -1,0 +1,63 @@
+# Lambda function logs are delivered by the Lambda service from outside this
+# VPC, so the CloudWatch Logs interface endpoint is not needed to see them.
+# Verified against prod by applying a deny-all endpoint policy and confirming
+# both an invocation marker and a live request still reached CloudWatch. At
+# ~$7.44/mo per endpoint it is the single largest avoidable line item, so the
+# default must stay opt-out-able and environments must be free to drop it.
+
+mock_provider "aws" {}
+
+variables {
+  prefix                 = "example"
+  aws_region             = "us-east-1"
+  create_vpc             = true
+  vpc_cidr               = "10.1.0.0/16"
+  create_public_subnets  = true
+  create_private_subnets = true
+  create_db_subnets      = true
+  create_vpc_endpoints   = true
+}
+
+run "logs_endpoint_is_present_by_default" {
+  command = plan
+
+  assert {
+    condition     = contains(keys(aws_vpc_endpoint.interface), "logs")
+    error_message = "The default must not silently remove an endpoint from existing environments."
+  }
+}
+
+run "logs_endpoint_can_be_dropped" {
+  command = plan
+
+  variables {
+    enable_logs_endpoint = false
+  }
+
+  assert {
+    condition     = !contains(keys(aws_vpc_endpoint.interface), "logs")
+    error_message = "enable_logs_endpoint=false must remove the CloudWatch Logs interface endpoint."
+  }
+}
+
+run "dropping_logs_leaves_the_endpoints_lambda_actually_needs" {
+  command = plan
+
+  variables {
+    enable_logs_endpoint = false
+    enable_ses_endpoint  = true
+  }
+
+  assert {
+    condition = alltrue([
+      for name in ["secretsmanager", "geo_places", "ses"] :
+      contains(keys(aws_vpc_endpoint.interface), name)
+    ])
+    error_message = "Secrets Manager, Location and SES are reached over their endpoints and must survive dropping the Logs endpoint."
+  }
+
+  assert {
+    condition     = length(keys(aws_vpc_endpoint.interface)) == 3
+    error_message = "Exactly three interface endpoints should remain; each extra one bills hourly."
+  }
+}

--- a/terraform/modules/networking/tests/ses_endpoint.tftest.hcl
+++ b/terraform/modules/networking/tests/ses_endpoint.tftest.hcl
@@ -1,0 +1,65 @@
+# Lambda runs in private subnets with no NAT and no default route, so the only
+# way it can reach SES is through an interface VPC endpoint. These tests pin
+# that the endpoint is created on demand and stays opt-in, because each
+# interface endpoint carries a standing hourly cost per environment.
+
+mock_provider "aws" {}
+
+variables {
+  prefix                 = "example"
+  aws_region             = "us-east-1"
+  create_vpc             = true
+  vpc_cidr               = "10.1.0.0/16"
+  create_public_subnets  = true
+  create_private_subnets = true
+  create_db_subnets      = true
+  create_vpc_endpoints   = true
+}
+
+run "ses_endpoint_is_absent_by_default" {
+  command = plan
+
+  assert {
+    condition     = !contains(keys(aws_vpc_endpoint.interface), "ses")
+    error_message = "The SES interface endpoint must be opt-in so other environments do not pay for it."
+  }
+}
+
+run "ses_endpoint_is_created_when_enabled" {
+  command = plan
+
+  variables {
+    enable_ses_endpoint = true
+  }
+
+  assert {
+    condition     = contains(keys(aws_vpc_endpoint.interface), "ses")
+    error_message = "enable_ses_endpoint must create an interface endpoint for SES."
+  }
+
+  assert {
+    condition     = aws_vpc_endpoint.interface["ses"].service_name == "com.amazonaws.us-east-1.email"
+    error_message = "The endpoint must target the SES API service (com.amazonaws.<region>.email), which private DNS maps onto email.<region>.amazonaws.com."
+  }
+
+  assert {
+    condition     = aws_vpc_endpoint.interface["ses"].private_dns_enabled
+    error_message = "Private DNS must be enabled so boto3's default SES endpoint resolves to the VPC endpoint without an endpoint_url override."
+  }
+}
+
+run "existing_endpoints_are_unaffected_by_the_ses_flag" {
+  command = plan
+
+  variables {
+    enable_ses_endpoint = true
+  }
+
+  assert {
+    condition = alltrue([
+      for name in ["secretsmanager", "logs", "geo_places"] :
+      contains(keys(aws_vpc_endpoint.interface), name)
+    ])
+    error_message = "Enabling the SES endpoint must not disturb the existing interface endpoints."
+  }
+}

--- a/terraform/modules/networking/variables.tf
+++ b/terraform/modules/networking/variables.tf
@@ -124,3 +124,14 @@ variable "enable_single_az_endpoints" {
   default     = false
 }
 
+variable "enable_ses_endpoint" {
+  description = "Create an interface VPC endpoint for the SES API so Lambda in private subnets can send email without internet egress"
+  type        = bool
+  default     = false
+
+  validation {
+    condition     = var.enable_ses_endpoint == false || var.create_vpc_endpoints == true
+    error_message = "enable_ses_endpoint requires create_vpc_endpoints to be true; the SES endpoint reuses the shared endpoint security group."
+  }
+}
+

--- a/terraform/modules/networking/variables.tf
+++ b/terraform/modules/networking/variables.tf
@@ -124,6 +124,12 @@ variable "enable_single_az_endpoints" {
   default     = false
 }
 
+variable "enable_logs_endpoint" {
+  description = "Create an interface VPC endpoint for the CloudWatch Logs API. Not required for Lambda function logs, which the Lambda service delivers outside the VPC; enable only for code that calls the Logs API directly"
+  type        = bool
+  default     = true
+}
+
 variable "enable_ses_endpoint" {
   description = "Create an interface VPC endpoint for the SES API so Lambda in private subnets can send email without internet egress"
   type        = bool

--- a/terraform/modules/ses/main.tf
+++ b/terraform/modules/ses/main.tf
@@ -179,6 +179,33 @@ resource "aws_ses_configuration_set" "main" {
   name = "${var.prefix}-config-set"
 }
 
+data "aws_caller_identity" "current" {}
+
+# Permit SES to publish only this configuration set's events to the topic.
+resource "aws_sns_topic_policy" "ses_notifications" {
+  count = var.enable_notifications ? 1 : 0
+  arn   = aws_sns_topic.ses_notifications[0].arn
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid       = "AllowSESPublish"
+        Effect    = "Allow"
+        Principal = { Service = "ses.amazonaws.com" }
+        Action    = "sns:Publish"
+        Resource  = aws_sns_topic.ses_notifications[0].arn
+        Condition = {
+          StringEquals = {
+            "AWS:SourceAccount" = data.aws_caller_identity.current.account_id
+            "AWS:SourceArn"     = "arn:aws:ses:${var.aws_region}:${data.aws_caller_identity.current.account_id}:configuration-set/${aws_ses_configuration_set.main.name}"
+          }
+        }
+      }
+    ]
+  })
+}
+
 # Event destination for bounce/complaint notifications
 resource "aws_ses_event_destination" "sns" {
   count                  = var.enable_notifications ? 1 : 0
@@ -191,6 +218,8 @@ resource "aws_ses_event_destination" "sns" {
   }
 
   matching_types = ["bounce", "complaint", "delivery", "reject"]
+
+  depends_on = [aws_sns_topic_policy.ses_notifications]
 }
 
 # SNS topic for SES notifications

--- a/terraform/modules/ses/main.tf
+++ b/terraform/modules/ses/main.tf
@@ -105,6 +105,44 @@ resource "aws_iam_user_policy" "ses_smtp" {
   })
 }
 
+# Role-based sending for compute that can assume an IAM role (Lambda, ECS).
+# Preferred over the SMTP user below: no static access keys to store, rotate
+# or leak, and it works over the SES API interface VPC endpoint.
+resource "aws_iam_policy" "ses_send" {
+  count = length(var.sender_role_names) > 0 ? 1 : 0
+
+  name        = "${var.prefix}-ses-send"
+  description = "Allow sending mail through SES from the ${var.domain_name} domain"
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Action = [
+          "ses:SendEmail",
+          "ses:SendRawEmail"
+        ]
+        Resource = "*"
+        Condition = {
+          # StringLike, not StringEquals: StringEquals compares "*@domain"
+          # literally, so it matches no real address at all.
+          StringLike = {
+            "ses:FromAddress" = var.verify_domain ? ["*@${var.domain_name}", var.from_email] : [var.from_email]
+          }
+        }
+      }
+    ]
+  })
+}
+
+resource "aws_iam_role_policy_attachment" "ses_send" {
+  for_each = toset(var.sender_role_names)
+
+  role       = each.value
+  policy_arn = aws_iam_policy.ses_send[0].arn
+}
+
 # Calculate SES SMTP password using external data source
 data "external" "smtp_password" {
   program = ["python3", "${path.module}/scripts/calculate_ses_password.py"]

--- a/terraform/modules/ses/tests/notification_topic_policy.tftest.hcl
+++ b/terraform/modules/ses/tests/notification_topic_policy.tftest.hcl
@@ -1,0 +1,70 @@
+# SES configuration-set events are published after a send is accepted. Without
+# an SNS resource policy, delivery, bounce, complaint, and reject events vanish
+# even though the application reports a successful send.
+
+mock_provider "aws" {
+  override_resource {
+    target = aws_sns_topic.ses_notifications
+    values = {
+      arn = "arn:aws:sns:us-east-1:123456789012:example-ses-notifications"
+    }
+  }
+
+  override_data {
+    target = data.aws_caller_identity.current
+    values = {
+      account_id = "123456789012"
+    }
+  }
+}
+
+variables {
+  prefix               = "example"
+  aws_region           = "us-east-1"
+  domain_name          = "example.org"
+  from_email           = "admin@example.org"
+  verify_domain        = true
+  enable_notifications = true
+}
+
+run "notification_topic_allows_only_this_ses_configuration_set" {
+  command = apply
+
+  assert {
+    condition     = length(aws_sns_topic_policy.ses_notifications) == 1
+    error_message = "SES notifications need an SNS topic policy or event publishing silently fails."
+  }
+
+  assert {
+    condition     = jsondecode(aws_sns_topic_policy.ses_notifications[0].policy).Statement[0].Principal.Service == "ses.amazonaws.com"
+    error_message = "The topic policy must authorize the SES service principal."
+  }
+
+  assert {
+    condition     = jsondecode(aws_sns_topic_policy.ses_notifications[0].policy).Statement[0].Action == "sns:Publish"
+    error_message = "SES only needs permission to publish notifications."
+  }
+
+  assert {
+    condition     = jsondecode(aws_sns_topic_policy.ses_notifications[0].policy).Statement[0].Condition.StringEquals["AWS:SourceAccount"] == data.aws_caller_identity.current.account_id
+    error_message = "The SES publish grant must be scoped to the current AWS account."
+  }
+
+  assert {
+    condition     = can(regex("configuration-set/example-config-set$", jsondecode(aws_sns_topic_policy.ses_notifications[0].policy).Statement[0].Condition.StringEquals["AWS:SourceArn"]))
+    error_message = "The SES publish grant must be scoped to this module's configuration set."
+  }
+}
+
+run "no_notification_topic_policy_when_notifications_are_disabled" {
+  command = plan
+
+  variables {
+    enable_notifications = false
+  }
+
+  assert {
+    condition     = length(aws_sns_topic_policy.ses_notifications) == 0
+    error_message = "Disabling notifications must not leave a topic policy behind."
+  }
+}

--- a/terraform/modules/ses/tests/role_send_policy.tftest.hcl
+++ b/terraform/modules/ses/tests/role_send_policy.tftest.hcl
@@ -1,0 +1,74 @@
+# Lambda authenticates to the SES API with its execution role, so the module
+# must be able to grant sending rights to a role instead of handing out the
+# static IAM access keys the SMTP path depends on.
+
+mock_provider "aws" {}
+
+variables {
+  prefix        = "example"
+  aws_region    = "us-east-1"
+  domain_name   = "example.org"
+  from_email    = "admin@example.org"
+  verify_domain = true
+}
+
+run "no_role_policy_without_sender_roles" {
+  command = plan
+
+  assert {
+    condition     = length(aws_iam_policy.ses_send) == 0
+    error_message = "The role-based send policy must only exist when a sender role is configured."
+  }
+
+  assert {
+    condition     = length(aws_iam_role_policy_attachment.ses_send) == 0
+    error_message = "No attachment should be created when no sender role is configured."
+  }
+}
+
+run "role_policy_grants_scoped_sending" {
+  command = plan
+
+  variables {
+    sender_role_names = ["example-zappa-deployment"]
+  }
+
+  assert {
+    condition = alltrue([
+      for action in ["ses:SendEmail", "ses:SendRawEmail"] :
+      contains(jsondecode(aws_iam_policy.ses_send[0].policy).Statement[0].Action, action)
+    ])
+    error_message = "The role must be allowed to send both structured and raw messages."
+  }
+
+  assert {
+    condition = contains(
+      jsondecode(aws_iam_policy.ses_send[0].policy).Statement[0].Condition.StringLike["ses:FromAddress"],
+      "*@example.org"
+    )
+    error_message = "Sending must be scoped to the verified domain with StringLike; StringEquals treats '*' as a literal and silently matches nothing."
+  }
+
+  assert {
+    condition     = !can(jsondecode(aws_iam_policy.ses_send[0].policy).Statement[0].Condition.StringEquals)
+    error_message = "A StringEquals condition on ses:FromAddress cannot express the wildcard and must not be used here."
+  }
+
+  assert {
+    condition     = length(aws_iam_role_policy_attachment.ses_send) == 1
+    error_message = "The send policy must be attached to each configured sender role."
+  }
+}
+
+run "role_policy_attaches_to_every_sender_role" {
+  command = plan
+
+  variables {
+    sender_role_names = ["example-zappa-deployment", "example-worker"]
+  }
+
+  assert {
+    condition     = length(aws_iam_role_policy_attachment.ses_send) == 2
+    error_message = "Every configured sender role must receive the send policy."
+  }
+}

--- a/terraform/modules/ses/variables.tf
+++ b/terraform/modules/ses/variables.tf
@@ -77,3 +77,8 @@ variable "secret_recovery_days" {
   type        = number
   default     = 7
 }
+variable "sender_role_names" {
+  description = "IAM role names to grant SES sending rights, so role-based compute (Lambda) can send without static SMTP credentials"
+  type        = list(string)
+  default     = []
+}


### PR DESCRIPTION
## Problem

Transactional email was silently broken in production. Endorsement verification links, admin notifications, and approval confirmations were written to CloudWatch and never delivered — the endorsement flow was effectively dead. The production database shows **6 endorsements, 0 ever verified**; five of them even carry a `verification_sent_at` timestamp for mail that was never actually sent.

Three independent problems compounded, and each one alone was enough to break delivery:

1. **No network path to SES.** Lambda runs in private subnets with no NAT and no `0.0.0.0/0` route, so `email-smtp.us-east-1.amazonaws.com:587` was unreachable — connections hung rather than failing fast.
2. **The failure was swallowed.** `SafeSMTPBackend` socket-probed the host and, on failure, returned `console_backend.send_messages(...)`, so Django reported success for mail that only reached a log. Nothing surfaced the outage.
3. **No email settings on the function.** The deployed Lambda carried none, so Django fell back to its local defaults — `SITE_URL` of `http://localhost:3000`. Even a delivered message would have carried an unusable verification link.

Two further findings turned up during investigation: SES was still in the **sandbox** (contradicting the assumption that it was not), which rejects every recipient outside the verified domain; and the existing SMTP IAM policy scopes `ses:FromAddress` with `StringEquals` on the configured sender-domain wildcard, which compares the wildcard literally and has therefore never matched any address.

## Approach

Lambda now sends through the **SES API over a VPC interface endpoint, authenticated by its execution role**, rather than SMTP with static credentials. Private DNS on the `com.amazonaws.<region>.email` endpoint covers `email.<region>.amazonaws.com`, so the AWS SDK needs no `endpoint_url` override. Other deployment targets keep using SES over SMTP.

Making failures loud required care at the call site. `create_endorsement` sends inside `transaction.atomic()` and wraps it in a bare `except Exception -> HttpError(500)`, so simply raising would have rolled back the stakeholder, endorsement, and terms acceptance the user had just submitted — converting a mail outage into silent data loss. The backends therefore raise, and the email service catches at its boundary, returning `False` with a logged traceback so the submission survives and stays resendable. Loudness moves to a CloudWatch alarm on the `EMAIL_DELIVERY_FAILED` marker.

## Already applied — merging only ships the code

The infrastructure in this PR **is already live in production** (targeted `terraform apply`: 7 added, 0 changed, 0 destroyed), and the prod GitHub environment variables are already set. Those are recorded here so config matches reality, not as pending work. SES production access has also been granted (quota now 50,000/day at 14/sec, up from 200/day at 1/sec).

What merging changes is the **application code**: the running Lambda still executes the old `SafeSMTPBackend` pointed at unreachable SMTP.

## Verification

Run from inside the `coalition-prod` Lambda, against the live VPC:

- `email.us-east-1.amazonaws.com` resolves to `10.1.3.232`, a private VPC address; TCP 443 connects in 0.0s
- A real email was **delivered to an external Gmail address** — outside the verified domain, which the sandbox would have rejected outright. CloudWatch `AWS/SES`: `Send=1, Delivery=1, Bounce=0, Complaint=0, Reject=0`
- Two sender addresses on the configured domain confirmed to pass the new `StringLike` policy

Local gates: 223 Python tests, 8 new `terraform test` cases, ruff/black/mypy clean, `terraform fmt`/`validate` clean, `mkdocs build --strict` passes. Written test-first throughout — each suite was confirmed red before implementation.

## Reviewer notes

- **The socket probe is deleted, not rewired.** It existed only to enable the silent fallback; with the fallback gone it had no remaining purpose.
- **`email_service.py` shows a large diff** because the three send methods each duplicated a slightly different try/except ladder — and none caught botocore errors, so the SES backend's failures would have escaped. Delivery is now one shared path. Public API is unchanged.
- **Terraform changes are opt-in** (`enable_ses_endpoint`, `sender_role_names`, `application_log_group_name`, `enable_logs_endpoint`), so the top-level root is untouched. Only prod and dev opt out of the Logs endpoint.
- **Prod deploys now fail without `SITE_URL` and `DEFAULT_FROM_EMAIL`**, mirroring how `CLOUDFRONT_DOMAIN` is already enforced. Both are set, so this is a guard against regression rather than a blocker.

## Cost

Net zero. The SES endpoint adds ~$7.44/mo, and this branch removes the CloudWatch Logs endpoint that was costing the same and doing nothing.

Lambda function logs are delivered by the Lambda service from outside the customer VPC, so that endpoint was never on the path carrying them, and nothing in the application calls the Logs API. Verified against prod rather than assumed: applying a deny-all endpoint policy (reversible, destroying nothing) left both an invocation marker and a live request still arriving in CloudWatch. After removal, cold starts, requests and SES sends were all re-confirmed working.

Prod VPC endpoints were $22.32 of a ~$31.92 monthly bill — roughly 70% — so this was the largest avoidable line item. Prod remains at $22.32/mo: the new SES endpoint replaces the unused Logs endpoint, keeping the total at three. Dev does not enable SES by default, so removing Logs reduces its endpoint count from three to two whenever VPC endpoints are enabled, saving another ~$7.44/mo.

## Follow-up

#310 tracks removing the now-unused static SMTP IAM user, access key, and secret. Deliberately deferred: deleting live production credentials is not something to bundle into an outage fix, and `SafeSMTPBackend` still serves non-Lambda deployments.

After merge and deploy, the 6 unverified endorsements can be requeued with the admin's existing "send verification emails" bulk action.
