### PR TITLE
Backend test suite fails nondeterministically depending on the pytest-xdist worker count

### DIFF
--- a/backend/coalition/api/tests/test_address.py
+++ b/backend/coalition/api/tests/test_address.py
@@ -11,6 +11,18 @@ class TestAddressAPI(TestCase):
         """Set up test client"""
         self.client = Client()
 
+    def test_uses_application_client_without_reassigning_router(self) -> None:
+        """Keep the address router attached to the application API."""
+        assert isinstance(self.client, Client)
+
+        response = self.client.get("/api/address/suggestions/?q=ab")
+
+        from coalition.api.address import router
+        from coalition.api.api import api
+
+        assert response.status_code == 400
+        assert router.api is api
+
     @patch("coalition.api.address.GeocodingService")
     def test_get_address_suggestions_success_with_proxied_path(
         self,


### PR DESCRIPTION
Closes #313

## Summary

- identifies `ninja.testing.TestClient(router)` in the address API tests as the source of shared router mutation
- confirms the existing switch to Django Client routes prevents the worker-order-dependent API import failure
- adds a regression guard that verifies address tests use the application client and preserve the central API router registration

## Verification

- regression guard fails on b7090219 with the old Ninja TestClient and passes on this branch
- 794 tests pass with `pytest --dist loadscope` at `-n 1`, `-n 2`, `-n 4`, and `-n 8`
- Ruff format and lint pass
- mypy passes for all 221 backend source files