### PR TITLE
fix(frontend): space footer branding from social links

### DIFF
--- a/frontend/components/Footer.tsx
+++ b/frontend/components/Footer.tsx
@@ -29,9 +29,9 @@ const Footer: React.FC<FooterProps> = ({
     <footer className={className || "bg-gray-900"}>
       <div className="max-w-7xl mx-auto section-spacing container-padding">
         {/* Main Footer Content */}
-        <div className="grid grid-cols-1 lg:grid-cols-4 gap-8 lg:gap-12 mb-8 justify-items-center lg:justify-items-start items-start">
+        <div className="grid grid-cols-1 lg:grid-cols-5 gap-8 lg:gap-12 mb-8 justify-items-center lg:justify-items-start items-start">
           {/* Logo and Tagline Column */}
-          <div className="lg:col-span-1">
+          <div className="lg:col-span-2">
             <div className="flex flex-col items-center lg:items-start">
               {/* Logo */}
               {orgInfo.theme?.logo_url ? (

--- a/frontend/components/__tests__/Footer.test.tsx
+++ b/frontend/components/__tests__/Footer.test.tsx
@@ -95,4 +95,16 @@ describe("Footer navigation", () => {
     expect(screen.getByText("Test Organization")).toBeInTheDocument();
     expect(screen.getByText("Test tagline")).toBeInTheDocument();
   });
+
+  it("gives the organization wordmark extra desktop grid space", () => {
+    render(<Footer orgInfo={mockHomepage} />);
+
+    const mainFooterGrid = screen
+      .getByRole("contentinfo")
+      .querySelector(".grid");
+    const organizationColumn = mainFooterGrid?.firstElementChild;
+
+    expect(mainFooterGrid).toHaveClass("lg:grid-cols-5");
+    expect(organizationColumn).toHaveClass("lg:col-span-2");
+  });
 });


### PR DESCRIPTION
## Summary

- allocate two desktop grid tracks to the footer branding section
- preserve the existing single-column mobile layout and spacing utilities
- add regression coverage for the desktop footer grid proportions

## Why

Long organization wordmarks could consume the entire gap before the “Follow Us” column because all four footer sections received equal-width desktop tracks. Giving branding a wider share preserves visible whitespace without adding organization-specific margins.

## User impact

Desktop footers now maintain clear separation between long site logos or organization names and the social links section.

## Validation

- `npm test -- --runInBand components/__tests__/Footer.test.tsx`
- `npx eslint components/Footer.tsx components/__tests__/Footer.test.tsx`
- `npx prettier --check components/Footer.tsx components/__tests__/Footer.test.tsx`
- `npm run typecheck`
- `git diff --check`