### PR TITLE
Fix footer admin links across environments

### DIFF
--- a/frontend/components/Footer.tsx
+++ b/frontend/components/Footer.tsx
@@ -13,6 +13,9 @@ interface FooterProps {
   className?: string;
 }
 
+const getAdminUrl = (apiBaseUrl: string | undefined): string =>
+  `${apiBaseUrl?.replace(/\/+$/, "") ?? ""}/admin/`;
+
 const Footer: React.FC<FooterProps> = ({
   orgInfo,
   showSocialLinks = true,
@@ -24,6 +27,7 @@ const Footer: React.FC<FooterProps> = ({
   }
 
   const currentYear = new Date().getFullYear();
+  const adminUrl = getAdminUrl(process.env.NEXT_PUBLIC_API_URL);
 
   return (
     <footer className={className || "bg-gray-900"}>
@@ -159,7 +163,7 @@ const Footer: React.FC<FooterProps> = ({
                   </li>
                   <li>
                     <Link
-                      href="/admin/"
+                      href={adminUrl}
                       className="text-gray-400 hover:text-white transition-colors duration-200 hover:underline text-sm sm:text-base"
                     >
                       Admin Login

--- a/frontend/components/__tests__/Footer.test.tsx
+++ b/frontend/components/__tests__/Footer.test.tsx
@@ -59,6 +59,17 @@ jest.mock("next/link", () => {
 });
 
 describe("Footer navigation", () => {
+  const originalApiUrl = process.env.NEXT_PUBLIC_API_URL;
+
+  afterEach(() => {
+    if (originalApiUrl === undefined) {
+      delete process.env.NEXT_PUBLIC_API_URL;
+      return;
+    }
+
+    process.env.NEXT_PUBLIC_API_URL = originalApiUrl;
+  });
+
   it("renders Terms of Use and Privacy Policy links", () => {
     render(<Footer orgInfo={mockHomepage} />);
 
@@ -87,6 +98,28 @@ describe("Footer navigation", () => {
     expect(screen.getByText("Campaigns")).toHaveAttribute("href", "/campaigns");
     expect(screen.getByText("About")).toHaveAttribute("href", "/about");
     expect(screen.getByText("Contact")).toHaveAttribute("href", "/contact");
+  });
+
+  it("builds the production admin link from the configured API URL", () => {
+    process.env.NEXT_PUBLIC_API_URL = "https://api.landandbay.org";
+
+    render(<Footer orgInfo={mockHomepage} />);
+
+    expect(screen.getByText("Admin Login")).toHaveAttribute(
+      "href",
+      "https://api.landandbay.org/admin/"
+    );
+  });
+
+  it("builds the development admin link without a duplicate slash", () => {
+    process.env.NEXT_PUBLIC_API_URL = "https://test-api.landandbay.org/";
+
+    render(<Footer orgInfo={mockHomepage} />);
+
+    expect(screen.getByText("Admin Login")).toHaveAttribute(
+      "href",
+      "https://test-api.landandbay.org/admin/"
+    );
   });
 
   it("renders organization name and tagline", () => {


### PR DESCRIPTION
## Summary

- derive the footer Admin Login URL from the configured public API base URL
- preserve the `/admin/` path while normalizing trailing slashes
- cover production and development API hosts in the footer component tests

## Why

The footer previously used the relative `/admin/` path, which routed users to the frontend host instead of the environment-specific Django admin. Reusing `NEXT_PUBLIC_API_URL` keeps the hostname configuration in one place and selects the correct backend in production, development, and preview deployments.

## Impact

The Admin Login footer link now opens the admin endpoint on the API host configured for the current deployment.

## Validation

- `npm test -- --runInBand components/__tests__/Footer.test.tsx`
- `npm run typecheck`
- `npx prettier --check components/Footer.tsx components/__tests__/Footer.test.tsx`
- `npx eslint components/Footer.tsx`