### PR TITLE
fix(lambda): ship the project template directory in the image

### DIFF
--- a/backend/coalition/core/tests/test_lambda_image_contents.py
+++ b/backend/coalition/core/tests/test_lambda_image_contents.py
@@ -57,7 +57,11 @@ def _sources_copied_to_workdir(dockerfile: str) -> set[str]:
 def _template_dirs_below_base() -> list[str]:
     """Names of configured template directories that live inside ``BASE_DIR``."""
     base = Path(settings.BASE_DIR).resolve()
-    configured = (Path(entry).resolve() for entry in settings.TEMPLATES[0]["DIRS"])
+    configured = (
+        Path(entry).resolve()
+        for backend in settings.TEMPLATES
+        for entry in backend.get("DIRS", [])
+    )
     return [
         str(directory.relative_to(base))
         for directory in configured
@@ -84,6 +88,20 @@ COPY templates/ ./scripts/
     def test_settings_configure_a_template_dir_inside_the_project(self) -> None:
         """Guards the test below against passing on an empty expectation."""
         assert _template_dirs_below_base()
+
+    def test_template_dirs_are_collected_from_every_backend(self) -> None:
+        template_backend = settings.TEMPLATES[0]
+        configured_backends = [
+            {**template_backend, "NAME": "empty", "DIRS": []},
+            {
+                **template_backend,
+                "NAME": "project",
+                "DIRS": [Path(settings.BASE_DIR) / "extra_templates"],
+            },
+        ]
+
+        with self.settings(TEMPLATES=configured_backends):
+            assert _template_dirs_below_base() == ["extra_templates"]
 
     def test_every_configured_template_dir_is_copied_into_the_image(self) -> None:
         copied = _copied_sources()

--- a/backend/coalition/core/tests/test_lambda_image_contents.py
+++ b/backend/coalition/core/tests/test_lambda_image_contents.py
@@ -28,6 +28,10 @@ def _sources_copied_to_workdir(dockerfile: str) -> set[str]:
     sources: set[str] = set()
     for line in dockerfile.splitlines():
         instruction = line.strip()
+        if instruction.upper().startswith("FROM "):
+            workdir = PurePosixPath("/")
+            sources.clear()
+            continue
         if instruction.upper().startswith("WORKDIR "):
             configured_workdir = PurePosixPath(instruction.split(maxsplit=1)[1])
             workdir = (
@@ -77,6 +81,18 @@ class LambdaImageCopiesConfiguredTemplateDirsTest(SimpleTestCase):
 WORKDIR /var/task
 COPY coalition/ ./coalition/
 COPY templates/ ./scripts/
+"""
+
+        assert "templates" not in _sources_copied_to_workdir(dockerfile)
+
+    def test_copy_in_discarded_stage_does_not_count(self) -> None:
+        dockerfile = """\
+FROM python:3.13 AS builder
+WORKDIR /var/task
+COPY templates/ ./templates/
+FROM python:3.13 AS app
+WORKDIR /var/task
+COPY coalition/ ./coalition/
 """
 
         assert "templates" not in _sources_copied_to_workdir(dockerfile)

--- a/backend/coalition/core/tests/test_lambda_image_contents.py
+++ b/backend/coalition/core/tests/test_lambda_image_contents.py
@@ -1,0 +1,66 @@
+"""The Lambda image must ship every directory the settings tell Django to read.
+
+``docker/app/Dockerfile.lambda`` builds what actually runs in production, and it
+copies an enumerated list of paths rather than the whole tree. Anything settings
+reference but that list omits fails only at runtime, in production: a template
+outside an installed app resolves to Django's fallback or raises
+``TemplateDoesNotExist``, with nothing at build or test time to say why. Deriving
+the expectation from ``settings.TEMPLATES`` keeps that list honest as the
+settings change.
+"""
+
+from pathlib import Path
+
+from django.conf import settings
+from django.test import SimpleTestCase
+
+LAMBDA_DOCKERFILE = Path(settings.BASE_DIR) / "docker" / "app" / "Dockerfile.lambda"
+
+
+def _copied_sources() -> set[str]:
+    """Build-context paths the Lambda image copies, normalized without slashes."""
+    sources: set[str] = set()
+    for line in LAMBDA_DOCKERFILE.read_text().splitlines():
+        instruction = line.strip()
+        if not instruction.upper().startswith("COPY "):
+            continue
+        arguments = [
+            argument
+            for argument in instruction.split()[1:]
+            if not argument.startswith("--")
+        ]
+        sources.update(argument.rstrip("/") for argument in arguments[:-1])
+    return sources
+
+
+def _template_dirs_below_base() -> list[str]:
+    """Names of configured template directories that live inside ``BASE_DIR``."""
+    base = Path(settings.BASE_DIR).resolve()
+    configured = (Path(entry).resolve() for entry in settings.TEMPLATES[0]["DIRS"])
+    return [
+        str(directory.relative_to(base))
+        for directory in configured
+        if directory.is_relative_to(base)
+    ]
+
+
+class LambdaImageCopiesConfiguredTemplateDirsTest(SimpleTestCase):
+    """A configured template directory left out of the image breaks only in prod."""
+
+    def test_the_dockerfile_copy_list_is_readable(self) -> None:
+        """Guards the two tests below against silently parsing nothing."""
+        assert "coalition" in _copied_sources()
+
+    def test_settings_configure_a_template_dir_inside_the_project(self) -> None:
+        """Guards the test below against passing on an empty expectation."""
+        assert _template_dirs_below_base()
+
+    def test_every_configured_template_dir_is_copied_into_the_image(self) -> None:
+        copied = _copied_sources()
+
+        for directory in _template_dirs_below_base():
+            with self.subTest(template_dir=directory):
+                assert directory in copied, (
+                    f"settings.TEMPLATES reads {directory}/ but "
+                    f"{LAMBDA_DOCKERFILE.name} never copies it into the image"
+                )

--- a/backend/coalition/core/tests/test_lambda_image_contents.py
+++ b/backend/coalition/core/tests/test_lambda_image_contents.py
@@ -9,7 +9,7 @@ the expectation from ``settings.TEMPLATES`` keeps that list honest as the
 settings change.
 """
 
-from pathlib import Path
+from pathlib import Path, PurePosixPath
 
 from django.conf import settings
 from django.test import SimpleTestCase
@@ -18,10 +18,24 @@ LAMBDA_DOCKERFILE = Path(settings.BASE_DIR) / "docker" / "app" / "Dockerfile.lam
 
 
 def _copied_sources() -> set[str]:
-    """Build-context paths the Lambda image copies, normalized without slashes."""
+    """Build-context paths copied to matching locations below ``WORKDIR``."""
+    return _sources_copied_to_workdir(LAMBDA_DOCKERFILE.read_text())
+
+
+def _sources_copied_to_workdir(dockerfile: str) -> set[str]:
+    """Sources whose image destination matches their build-context path."""
+    workdir = PurePosixPath("/")
     sources: set[str] = set()
-    for line in LAMBDA_DOCKERFILE.read_text().splitlines():
+    for line in dockerfile.splitlines():
         instruction = line.strip()
+        if instruction.upper().startswith("WORKDIR "):
+            configured_workdir = PurePosixPath(instruction.split(maxsplit=1)[1])
+            workdir = (
+                configured_workdir
+                if configured_workdir.is_absolute()
+                else workdir / configured_workdir
+            )
+            continue
         if not instruction.upper().startswith("COPY "):
             continue
         arguments = [
@@ -29,7 +43,14 @@ def _copied_sources() -> set[str]:
             for argument in instruction.split()[1:]
             if not argument.startswith("--")
         ]
-        sources.update(argument.rstrip("/") for argument in arguments[:-1])
+        destination = PurePosixPath(arguments[-1])
+        resolved_destination = (
+            destination if destination.is_absolute() else workdir / destination
+        )
+        for argument in arguments[:-1]:
+            source = PurePosixPath(argument)
+            if resolved_destination == workdir / source:
+                sources.add(str(source))
     return sources
 
 
@@ -46,6 +67,15 @@ def _template_dirs_below_base() -> list[str]:
 
 class LambdaImageCopiesConfiguredTemplateDirsTest(SimpleTestCase):
     """A configured template directory left out of the image breaks only in prod."""
+
+    def test_copy_source_at_wrong_destination_does_not_count(self) -> None:
+        dockerfile = """\
+WORKDIR /var/task
+COPY coalition/ ./coalition/
+COPY templates/ ./scripts/
+"""
+
+        assert "templates" not in _sources_copied_to_workdir(dockerfile)
 
     def test_the_dockerfile_copy_list_is_readable(self) -> None:
         """Guards the two tests below against silently parsing nothing."""

--- a/backend/docker/app/Dockerfile.lambda
+++ b/backend/docker/app/Dockerfile.lambda
@@ -20,6 +20,9 @@ RUN poetry config virtualenvs.create false && \
 
 # Copy application code
 COPY coalition/ ./coalition/
+# settings.TEMPLATES adds BASE_DIR/templates ahead of the per-app directories;
+# without it the admin overrides and the endorsement emails have no templates.
+COPY templates/ ./templates/
 COPY scripts/ ./scripts/
 COPY manage.py ./
 COPY zappa_settings.json ./


### PR DESCRIPTION
## What broke

The "Admin guide" link added to the admin header in b9421921 does not appear in production, even though the guide itself at `/admin/help/` works.

`backend/docker/app/Dockerfile.lambda` — the file `deploy_lambda.yml` actually builds the deployed image from, *not* `backend/Dockerfile` — copies an enumerated list of paths rather than the whole tree, and `templates/` was never on it. `git log -p --all` on that Dockerfile shows the line has never existed. So in Lambda `BASE_DIR/templates` is absent, the `settings.TEMPLATES` `DIRS` entry points at nothing, and `admin/base_site.html` silently falls back to Django's own copy. No error, no link.

The guide kept working because its templates live inside the app (`coalition/admin_help/templates/`), which `APP_DIRS` finds. That asymmetry is why this surfaced as one missing link rather than a 500.

## The part that matters more than the link

`backend/templates/` also holds `templates/emails/`, and `endorsements/email_service.py` renders those by name (`emails/endorsement_verification`, `emails/admin_endorsement_notification`, `emails/endorsement_approved`). In `_deliver`, `render_to_string` runs *before* `send_mail`, inside the `except Exception` that logs `EMAIL_DELIVERY_FAILED` and returns `False` rather than raising. So in production every endorsement email has been failing at the render step, never reaching SES.

That is an independent second cause of the zero SES sends, separate from the missing VPC egress route — it would have persisted after the egress fix. This is inferred from the code and the Dockerfile, not yet confirmed against CloudWatch; grepping the prod log group for `EMAIL_DELIVERY_FAILED` would settle it. `templates/index.html`, used by `core/views.py:222`, was missing for the same reason.

## The fix

One `COPY templates/ ./templates/` line, plus a test that stops the list from drifting again.

`coalition/core/tests/test_lambda_image_contents.py` parses the Dockerfile's `COPY` instructions and asserts that every `settings.TEMPLATES` directory under `BASE_DIR` appears among them. The expectation is derived from the settings rather than restated as a second hardcoded list, so a template directory added later has to be copied too. Two guard tests keep it from passing vacuously if the Dockerfile is renamed or the settings stop configuring a project-level dir.

Written red first: it failed with `settings.TEMPLATES reads templates/ but Dockerfile.lambda never copies it into the image`, then passed with the `COPY` line added.

## Verification

- `pytest coalition/core/tests/test_lambda_image_contents.py coalition/admin_help/` — 38 passed, 231 subtests.
- `ruff format --check`, `ruff check`, `mypy` clean on the new file.
- Confirmed against Django 5.2.1 that `admin/base.html` still defines the `userlinks` block the override targets, and that `admin/base_site.html` resolves to our copy under this repo's `TEMPLATES` config.
- Not verified: that the image builds, since `Dockerfile.lambda` needs the ECR `geolambda` base. The change is a single `COPY` of a directory that exists in the build context.

## Deploying

**This needs a full image rebuild and push to take effect** — the templates are baked into the image, so a template-only change is not picked up by a Lambda config update.

## Review limitations

The guard test intentionally covers the deployed Dockerfile current shape: direct COPY instructions in a final stage with an explicit WORKDIR. Any refactor involving multiple runtime roots or named-stage inheritance must update the test or validate the built image directly.