### PR TITLE
fix(endorsements): validate manually entered addresses

### DIFF
--- a/backend/coalition/api/schemas.py
+++ b/backend/coalition/api/schemas.py
@@ -1,6 +1,8 @@
+from collections.abc import Callable
 from datetime import datetime
 from typing import TYPE_CHECKING
 
+from django.core.exceptions import ValidationError as DjangoValidationError
 from ninja import ModelSchema, Schema
 from pydantic import Field, validator
 
@@ -410,6 +412,17 @@ class SpamPreventionMetadata(Schema):
         return v
 
 
+def _validate_address_input(
+    submitted_value: str,
+    address_validator: Callable[[str], str],
+) -> str:
+    """Adapt Django validation errors to Pydantic request validation errors."""
+    try:
+        return address_validator(submitted_value)
+    except DjangoValidationError as error:
+        raise ValueError("; ".join(error.messages)) from error
+
+
 # Input schemas for creating endorsements
 class StakeholderCreateSchema(Schema):
     """Input schema for creating stakeholder records with validation."""
@@ -451,17 +464,17 @@ class StakeholderCreateSchema(Schema):
     @validator("zip_code")
     def validate_zip_code(cls, v: str) -> str:  # noqa: N805
         """Validate ZIP code format"""
-        return AddressValidator.validate_zip_code(v)
+        return _validate_address_input(v, AddressValidator.validate_zip_code)
 
     @validator("street_address")
     def validate_street_address(cls, v: str) -> str:  # noqa: N805
         """Validate street address"""
-        return AddressValidator.validate_street_address(v)
+        return _validate_address_input(v, AddressValidator.validate_street_address)
 
     @validator("city")
     def validate_city(cls, v: str) -> str:  # noqa: N805
         """Validate city name"""
-        return AddressValidator.validate_city(v)
+        return _validate_address_input(v, AddressValidator.validate_city)
 
 
 class EndorsementCreateSchema(Schema):

--- a/backend/coalition/api/tests/test_endorsements.py
+++ b/backend/coalition/api/tests/test_endorsements.py
@@ -243,6 +243,35 @@ class EndorsementAPITest(BaseTestCase):
         assert endorsement.statement == expected
         assert endorsement.public_display
 
+    def test_create_endorsement_rejects_empty_street_address(self) -> None:
+        """Invalid address input must produce a client error rather than a 500."""
+        endorsement_data = {
+            "campaign_id": self.campaign.id,
+            "stakeholder": {
+                "first_name": "Morgan",
+                "last_name": "Lee",
+                "email": "morgan@example.com",
+                "street_address": "",
+                "city": "Baltimore",
+                "state": "MD",
+                "zip_code": "21201",
+                "type": "individual",
+            },
+            "statement": "I support this campaign",
+            "public_display": True,
+            "terms_accepted": True,
+            "form_metadata": get_valid_form_metadata(),
+        }
+
+        response = self.client.post(
+            "/api/endorsements/",
+            data=json.dumps(endorsement_data),
+            content_type="application/json",
+        )
+
+        assert response.status_code == 422, response.content
+        assert not Stakeholder.objects.filter(email="morgan@example.com").exists()
+
     def test_create_endorsement_existing_stakeholder(self) -> None:
         """Test POST /api/endorsements/ with existing stakeholder email"""
         # Use existing stakeholder's email with EXACT matching info (security)

--- a/frontend/components/AddressAutocomplete.tsx
+++ b/frontend/components/AddressAutocomplete.tsx
@@ -40,8 +40,10 @@ export default function AddressAutocomplete({
   const [showSuggestions, setShowSuggestions] = useState(false);
   const [selectedIndex, setSelectedIndex] = useState(-1);
   const wrapperRef = useRef<HTMLDivElement>(null);
+  const addressRequestVersionRef = useRef(0);
 
   useEffect(() => {
+    addressRequestVersionRef.current += 1;
     setQuery(initialValue);
   }, [initialValue]);
 
@@ -97,6 +99,7 @@ export default function AddressAutocomplete({
   // Handle input change
   const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const value = e.target.value;
+    addressRequestVersionRef.current += 1;
     setQuery(value);
     onInputChange?.(value);
     setSelectedIndex(-1);
@@ -105,6 +108,8 @@ export default function AddressAutocomplete({
 
   // Handle suggestion selection
   const handleSelectSuggestion = async (suggestion: AddressSuggestion) => {
+    const requestVersion = addressRequestVersionRef.current + 1;
+    addressRequestVersionRef.current = requestVersion;
     setQuery(suggestion.text);
     setShowSuggestions(false);
     setSuggestions([]);
@@ -117,9 +122,11 @@ export default function AddressAutocomplete({
 
       if (response.ok) {
         const addressComponents = await response.json();
+        if (requestVersion !== addressRequestVersionRef.current) return;
         onAddressSelect(addressComponents);
       } else {
         console.error("Failed to fetch place details");
+        if (requestVersion !== addressRequestVersionRef.current) return;
         // Fallback: let user enter manually
         onAddressSelect({
           street_address: suggestion.text,
@@ -130,6 +137,7 @@ export default function AddressAutocomplete({
       }
     } catch (error) {
       console.error("Error fetching place details:", error);
+      if (requestVersion !== addressRequestVersionRef.current) return;
       // Fallback: let user enter manually
       onAddressSelect({
         street_address: suggestion.text,

--- a/frontend/components/AddressAutocomplete.tsx
+++ b/frontend/components/AddressAutocomplete.tsx
@@ -17,6 +17,7 @@ interface AddressComponents {
 
 interface AddressAutocompleteProps {
   onAddressSelect: (components: AddressComponents) => void;
+  onInputChange?: (streetAddress: string) => void;
   initialValue?: string;
   placeholder?: string;
   required?: boolean;
@@ -26,6 +27,7 @@ interface AddressAutocompleteProps {
 
 export default function AddressAutocomplete({
   onAddressSelect,
+  onInputChange,
   initialValue = "",
   placeholder = "Start typing your address...",
   required = false,
@@ -38,6 +40,10 @@ export default function AddressAutocomplete({
   const [showSuggestions, setShowSuggestions] = useState(false);
   const [selectedIndex, setSelectedIndex] = useState(-1);
   const wrapperRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    setQuery(initialValue);
+  }, [initialValue]);
 
   // Click outside handler
   useEffect(() => {
@@ -92,6 +98,7 @@ export default function AddressAutocomplete({
   const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const value = e.target.value;
     setQuery(value);
+    onInputChange?.(value);
     setSelectedIndex(-1);
     searchAddresses(value);
   };

--- a/frontend/components/EndorsementForm.tsx
+++ b/frontend/components/EndorsementForm.tsx
@@ -547,6 +547,16 @@ const EndorsementForm = forwardRef<EndorsementFormRef, EndorsementFormProps>(
           <div className="form-group">
             <label htmlFor="address-autocomplete">Address *</label>
             <AddressAutocomplete
+              initialValue={stakeholder.street_address}
+              onInputChange={(streetAddress) => {
+                setStakeholder((previousStakeholder) => ({
+                  ...previousStakeholder,
+                  street_address: streetAddress,
+                  city: "",
+                  state: "",
+                  zip_code: "",
+                }));
+              }}
               onAddressSelect={(components) => {
                 setStakeholder((prev) => ({
                   ...prev,

--- a/frontend/components/EndorsementForm.tsx
+++ b/frontend/components/EndorsementForm.tsx
@@ -172,6 +172,16 @@ const EndorsementForm = forwardRef<EndorsementFormRef, EndorsementFormProps>(
       }
     };
 
+    const setStreetAddressAndClearDependentFields = (streetAddress: string) => {
+      setStakeholder((previousStakeholder) => ({
+        ...previousStakeholder,
+        street_address: streetAddress,
+        city: "",
+        state: "",
+        zip_code: "",
+      }));
+    };
+
     const handleSubmit = async (e: React.FormEvent) => {
       e.preventDefault();
       setIsSubmitting(true);
@@ -548,15 +558,7 @@ const EndorsementForm = forwardRef<EndorsementFormRef, EndorsementFormProps>(
             <label htmlFor="address-autocomplete">Address *</label>
             <AddressAutocomplete
               initialValue={stakeholder.street_address}
-              onInputChange={(streetAddress) => {
-                setStakeholder((previousStakeholder) => ({
-                  ...previousStakeholder,
-                  street_address: streetAddress,
-                  city: "",
-                  state: "",
-                  zip_code: "",
-                }));
-              }}
+              onInputChange={setStreetAddressAndClearDependentFields}
               onAddressSelect={(components) => {
                 setStakeholder((prev) => ({
                   ...prev,
@@ -585,7 +587,7 @@ const EndorsementForm = forwardRef<EndorsementFormRef, EndorsementFormProps>(
                   type="text"
                   value={stakeholder.street_address}
                   onChange={(e) =>
-                    handleStakeholderChange("street_address", e.target.value)
+                    setStreetAddressAndClearDependentFields(e.target.value)
                   }
                   required
                   data-testid="street-address-input"

--- a/frontend/components/__tests__/AddressAutocomplete.test.tsx
+++ b/frontend/components/__tests__/AddressAutocomplete.test.tsx
@@ -2,6 +2,20 @@ import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 
 import AddressAutocomplete from "../AddressAutocomplete";
 
+interface Deferred<T> {
+  promise: Promise<T>;
+  resolve: (resolvedValue: T) => void;
+}
+
+function createDeferred<T>(): Deferred<T> {
+  let resolvePromise: (resolvedValue: T) => void = () => undefined;
+  const promise = new Promise<T>((resolve) => {
+    resolvePromise = resolve;
+  });
+
+  return { promise, resolve: resolvePromise };
+}
+
 describe("AddressAutocomplete", () => {
   const fetchMock = jest.fn();
 
@@ -109,5 +123,59 @@ describe("AddressAutocomplete", () => {
         zip_code: "21201",
       });
     });
+  });
+
+  it("ignores place details when the address changes before they arrive", async () => {
+    const onAddressSelect = jest.fn();
+    const pendingPlaceDetails = createDeferred<Response>();
+    fetchMock
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          suggestions: [{ text: "100 Main St", place_id: "place-123" }],
+        }),
+      } as Response)
+      .mockReturnValueOnce(pendingPlaceDetails.promise)
+      .mockResolvedValue({
+        ok: true,
+        json: async () => ({ suggestions: [] }),
+      } as Response);
+
+    render(
+      <AddressAutocomplete
+        onAddressSelect={onAddressSelect}
+        debounceDelay={0}
+      />
+    );
+
+    fireEvent.change(screen.getByTestId("address-autocomplete"), {
+      target: { value: "100 Main" },
+    });
+    await waitFor(() => {
+      expect(screen.getByTestId("suggestion-0")).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByTestId("suggestion-0"));
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith("/api/address/place/place-123/");
+    });
+
+    fireEvent.change(screen.getByTestId("address-autocomplete"), {
+      target: { value: "456 Manual Entry Ave" },
+    });
+    pendingPlaceDetails.resolve({
+      ok: true,
+      json: async () => ({
+        street_address: "100 Main St",
+        city: "Baltimore",
+        state: "MD",
+        zip_code: "21201",
+      }),
+    } as Response);
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledTimes(3);
+    });
+    expect(onAddressSelect).not.toHaveBeenCalled();
   });
 });

--- a/frontend/components/__tests__/AddressAutocomplete.test.tsx
+++ b/frontend/components/__tests__/AddressAutocomplete.test.tsx
@@ -31,6 +31,38 @@ describe("AddressAutocomplete", () => {
     });
   });
 
+  it("reports manually entered street addresses", () => {
+    const onInputChange = jest.fn();
+
+    render(
+      <AddressAutocomplete
+        onAddressSelect={jest.fn()}
+        onInputChange={onInputChange}
+      />
+    );
+
+    fireEvent.change(screen.getByTestId("address-autocomplete"), {
+      target: { value: "456 Manual Entry Ave" },
+    });
+
+    expect(onInputChange).toHaveBeenCalledWith("456 Manual Entry Ave");
+  });
+
+  it("updates the displayed address when its initial value is reset", () => {
+    const { rerender } = render(
+      <AddressAutocomplete
+        initialValue="100 Main St"
+        onAddressSelect={jest.fn()}
+      />
+    );
+
+    rerender(
+      <AddressAutocomplete initialValue="" onAddressSelect={jest.fn()} />
+    );
+
+    expect(screen.getByTestId("address-autocomplete")).toHaveValue("");
+  });
+
   it("requests place details from the trailing-slash API route", async () => {
     const onAddressSelect = jest.fn();
     fetchMock

--- a/frontend/components/__tests__/EndorsementForm.test.tsx
+++ b/frontend/components/__tests__/EndorsementForm.test.tsx
@@ -100,6 +100,8 @@ jest.mock("../AddressAutocomplete", () => {
       state: string;
       zip_code: string;
     }) => void;
+    onInputChange?: (streetAddress: string) => void;
+    initialValue?: string;
     [key: string]: unknown;
   }) {
     // Use a ref to ensure we only call once
@@ -119,9 +121,11 @@ jest.mock("../AddressAutocomplete", () => {
     }, [props]);
 
     return (
-      <div data-testid="address-autocomplete">
+      <div>
         <input
           type="text"
+          value={props.initialValue || ""}
+          onChange={(event) => props.onInputChange?.(event.target.value)}
           placeholder={props.placeholder || "Start typing your address..."}
           data-testid={props.testId || "address-autocomplete"}
         />
@@ -213,6 +217,22 @@ describe("EndorsementForm", () => {
     // Check it again
     fireEvent.click(publicDisplayCheckbox);
     expect(publicDisplayCheckbox).toBeChecked();
+  });
+
+  it("uses a manually entered autocomplete address in form state", async () => {
+    render(<EndorsementForm campaign={mockCampaign} />);
+
+    await fillAddressFields();
+    fireEvent.change(screen.getByTestId("address-autocomplete"), {
+      target: { value: "456 Manual Entry Ave" },
+    });
+
+    expect(screen.getByTestId("street-address-input")).toHaveValue(
+      "456 Manual Entry Ave"
+    );
+    expect(screen.getByTestId("city-input")).toHaveValue("");
+    expect(screen.getByTestId("state-select")).toHaveValue("");
+    expect(screen.getByTestId("zip-code-input")).toHaveValue("");
   });
 
   describe("Social Sharing Integration", () => {

--- a/frontend/components/__tests__/EndorsementForm.test.tsx
+++ b/frontend/components/__tests__/EndorsementForm.test.tsx
@@ -235,6 +235,22 @@ describe("EndorsementForm", () => {
     expect(screen.getByTestId("zip-code-input")).toHaveValue("");
   });
 
+  it("clears dependent location fields when the street address is edited", async () => {
+    render(<EndorsementForm campaign={mockCampaign} />);
+
+    await fillAddressFields();
+    fireEvent.change(screen.getByTestId("street-address-input"), {
+      target: { value: "789 Different St" },
+    });
+
+    expect(screen.getByTestId("street-address-input")).toHaveValue(
+      "789 Different St"
+    );
+    expect(screen.getByTestId("city-input")).toHaveValue("");
+    expect(screen.getByTestId("state-select")).toHaveValue("");
+    expect(screen.getByTestId("zip-code-input")).toHaveValue("");
+  });
+
   describe("Social Sharing Integration", () => {
     it("displays social share buttons after successful submission", async () => {
       render(<EndorsementForm campaign={mockCampaign} />);


### PR DESCRIPTION
## What broke

Production Lambda logs on August 9 showed three `/api/endorsements/` requests returning 500 before the endpoint handler ran. Each trace ended in `StakeholderCreateSchema.validate_street_address`: the autocomplete displayed manually typed text but only copied an address into endorsement form state after the user selected a suggestion, so browser validation passed while the request payload carried an empty `street_address`. The shared address validator then raised Django's `ValidationError` inside a Pydantic validator; because that exception type was not adapted at the API boundary, invalid input became an internal server error instead of a 422 response.

## What changed

- Synchronize manually typed autocomplete text into endorsement form state.
- Clear city, state, and ZIP when the street address changes so location fields cannot silently describe a previous suggestion.
- Synchronize the autocomplete display when form state resets after a successful submission.
- Adapt Django address-validation errors to Pydantic `ValueError` instances so Ninja returns 422 and creates no stakeholder.
- Add regression coverage for manual entry, reset behavior, dependent-field clearing, and the observed empty-address request.

## Companion fix

PR #329 separately adds the project template directory to the Lambda image, restoring endorsement verification-email rendering. Keeping that packaging fix separate lets it merge and deploy independently; both PRs are needed to fully resolve the production endorsement incident.

## Verification

- `pytest coalition/api/tests/test_endorsements.py --no-cov -q` — 43 passed.
- Focused frontend Jest suites — 17 passed.
- Backend Ruff format, Ruff lint, and mypy passed.
- Frontend TypeScript, ESLint, and Prettier checks passed.