### PR TITLE
fix(endorsements): complete submission verification flow

### DIFF
--- a/backend/coalition/api/endorsements.py
+++ b/backend/coalition/api/endorsements.py
@@ -306,7 +306,7 @@ def _perform_spam_checks(
         )
 
 
-def _create_endorsement_with_emails(
+def _create_endorsement(
     campaign: PolicyCampaign,
     stakeholder_data: dict,
     statement: str,
@@ -315,9 +315,9 @@ def _create_endorsement_with_emails(
     org_authorized: bool,
     ip_address: str,
     request: HttpRequest,
-) -> Endorsement:
+) -> tuple[Endorsement, bool]:
     """
-    Create endorsement and handle email notifications.
+    Persist an endorsement and its terms acceptance record.
     """
     # Validate terms acceptance
     if not terms_accepted:
@@ -366,20 +366,47 @@ def _create_endorsement_with_emails(
             user_agent=request.META.get("HTTP_USER_AGENT", ""),
         )
 
-    # Send verification email
-    email_sent = EndorsementEmailService.send_verification_email(endorsement)
+    return endorsement, created
+
+
+def _send_verification_email(endorsement: Endorsement) -> None:
+    """Send verification mail without invalidating a persisted submission."""
+    try:
+        email_sent = EndorsementEmailService.send_verification_email(endorsement)
+    except Exception:
+        logger.exception(
+            "Unexpected verification-email failure for endorsement %s",
+            endorsement.id,
+        )
+        return
+
     if not email_sent:
-        # Log error with additional context for debugging
         logger.error(
-            f"Failed to send verification email for endorsement "
-            f"{endorsement.id} to {stakeholder.email}. Email delivery failed.",
+            "Failed to send verification email for endorsement %s. "
+            "Email delivery failed.",
+            endorsement.id,
         )
 
-    # Send admin notification for new endorsements
-    if created:
-        EndorsementEmailService.send_admin_notification(endorsement)
 
-    return endorsement
+def _notify_admins_of_new_endorsement(endorsement: Endorsement) -> None:
+    """Notify admins without invalidating a persisted submission."""
+    try:
+        EndorsementEmailService.send_admin_notification(endorsement)
+    except Exception:
+        logger.exception(
+            "Unexpected admin-notification failure for endorsement %s",
+            endorsement.id,
+        )
+
+
+def _send_endorsement_notifications(
+    endorsement: Endorsement,
+    created: bool,
+) -> None:
+    """Send post-commit notifications for a persisted endorsement."""
+    _send_verification_email(endorsement)
+    if created:
+        _notify_admins_of_new_endorsement(endorsement)
 
 
 @router.get("/", response=list[PublicEndorsementOut], auth=None)
@@ -442,7 +469,7 @@ def create_endorsement(
 
     try:
         with transaction.atomic():
-            return _create_endorsement_with_emails(
+            endorsement, created = _create_endorsement(
                 campaign,
                 stakeholder_data,
                 data.statement,
@@ -460,6 +487,9 @@ def create_endorsement(
         raise
     except Exception as e:
         raise HttpError(500, f"Unexpected error: {str(e)}") from e
+
+    _send_endorsement_notifications(endorsement, created)
+    return endorsement
 
 
 @router.post("/verify/{token}/", auth=None)

--- a/backend/coalition/api/tests/test_endorsements.py
+++ b/backend/coalition/api/tests/test_endorsements.py
@@ -9,6 +9,7 @@ from unittest.mock import Mock, patch
 from botocore.exceptions import ClientError
 from django.contrib.auth.models import Permission, User
 from django.core.cache import cache
+from django.db import OperationalError
 from django.http import HttpResponse
 from django.test import Client, override_settings
 from django.utils import timezone
@@ -115,6 +116,20 @@ class EndorsementSurvivesEmailOutageTest(BaseTestCase):
         )
         assert endorsement.status == "pending"
         assert endorsement.email_verified is False
+
+    def test_endorsement_persists_when_verification_notification_raises(self) -> None:
+        with patch.object(
+            EndorsementEmailService,
+            "send_verification_email",
+            side_effect=OperationalError("timestamp save failed"),
+        ):
+            response = self.submit_endorsement()
+
+        assert response.status_code == 200, response.content
+        assert Endorsement.objects.filter(
+            stakeholder__email="dana@example.com",
+            campaign=self.campaign,
+        ).exists()
 
 
 class EndorsementAPITest(BaseTestCase):

--- a/backend/coalition/api/tests/test_endorsements.py
+++ b/backend/coalition/api/tests/test_endorsements.py
@@ -100,6 +100,22 @@ class EndorsementSurvivesEmailOutageTest(BaseTestCase):
         assert endorsement.verification_sent_at is None
         assert endorsement.email_verified is False
 
+    def test_endorsement_persists_when_admin_notification_raises(self) -> None:
+        with patch.object(
+            EndorsementEmailService,
+            "send_admin_notification",
+            side_effect=RuntimeError("unexpected notification failure"),
+        ):
+            response = self.submit_endorsement()
+
+        assert response.status_code == 200, response.content
+        endorsement = Endorsement.objects.get(
+            stakeholder__email="dana@example.com",
+            campaign=self.campaign,
+        )
+        assert endorsement.status == "pending"
+        assert endorsement.email_verified is False
+
 
 class EndorsementAPITest(BaseTestCase):
     """Test basic endorsement API endpoints"""

--- a/backend/coalition/endorsements/email_service.py
+++ b/backend/coalition/endorsements/email_service.py
@@ -46,8 +46,12 @@ def _deliver(email: _OutboundEmail) -> bool:
     delivery-failure marker so they still page an operator.
     """
     try:
-        plain_message = render_to_string(f"{email.template_base}.txt", email.context)
-        html_message = render_to_string(f"{email.template_base}.html", email.context)
+        email_context = {
+            **email.context,
+            "organization_name": _organization_name(),
+        }
+        plain_message = render_to_string(f"{email.template_base}.txt", email_context)
+        html_message = render_to_string(f"{email.template_base}.html", email_context)
         sent_count = send_mail(
             subject=email.subject,
             message=plain_message,
@@ -88,13 +92,7 @@ def _admin_notification_recipients() -> list[str]:
 
 def _organization_name() -> str:
     """Return the public organization's name from the active homepage."""
-    try:
-        homepage = HomePage.get_active()
-    except Exception:
-        logger.exception(
-            "Could not load active homepage branding; using configured fallback",
-        )
-        return settings.ORGANIZATION_NAME
+    homepage = HomePage.get_active()
     if homepage:
         return homepage.organization_name
     return settings.ORGANIZATION_NAME
@@ -127,7 +125,6 @@ class EndorsementEmailService:
                     "campaign": endorsement.campaign,
                     "verification_url": verification_url,
                     "site_url": settings.SITE_URL,
-                    "organization_name": _organization_name(),
                 },
                 recipients=[endorsement.stakeholder.email],
                 description=f"verification email for endorsement {endorsement.id}",
@@ -162,7 +159,6 @@ class EndorsementEmailService:
                         f"{settings.API_URL}/admin/endorsements/endorsement/"
                         f"{endorsement.id}/change/"
                     ),
-                    "organization_name": _organization_name(),
                 },
                 recipients=recipients,
                 description=f"admin notification for endorsement {endorsement.id}",
@@ -186,7 +182,6 @@ class EndorsementEmailService:
                     "campaign_url": (
                         f"{settings.SITE_URL}/campaigns/{endorsement.campaign.name}/"
                     ),
-                    "organization_name": _organization_name(),
                 },
                 recipients=[endorsement.stakeholder.email],
                 description=f"approval confirmation for endorsement {endorsement.id}",

--- a/backend/coalition/endorsements/email_service.py
+++ b/backend/coalition/endorsements/email_service.py
@@ -11,6 +11,8 @@ from django.core.mail import send_mail
 from django.template.loader import render_to_string
 from django.utils import timezone
 
+from coalition.content.models import HomePage
+
 from .models import Endorsement
 
 logger = logging.getLogger(__name__)
@@ -39,11 +41,9 @@ class _OutboundEmail:
 def _deliver(email: _OutboundEmail) -> bool:
     """Render and send one message, reporting failure rather than raising.
 
-    Callers run inside ``transaction.atomic``: letting a transport error
-    propagate would roll back the endorsement the user just submitted, so a
-    broken mail path would destroy their submission instead of merely
-    delaying their verification link. Failures are logged with a traceback
-    and the delivery-failure marker so they still page an operator.
+    A broken mail path must delay a notification without invalidating the
+    endorsement it describes. Failures are logged with a traceback and the
+    delivery-failure marker so they still page an operator.
     """
     try:
         plain_message = render_to_string(f"{email.template_base}.txt", email.context)
@@ -86,6 +86,20 @@ def _admin_notification_recipients() -> list[str]:
     return [address for _name, address in getattr(settings, "ADMINS", [])]
 
 
+def _organization_name() -> str:
+    """Return the public organization's name from the active homepage."""
+    try:
+        homepage = HomePage.get_active()
+    except Exception:
+        logger.exception(
+            "Could not load active homepage branding; using configured fallback",
+        )
+        return settings.ORGANIZATION_NAME
+    if homepage:
+        return homepage.organization_name
+    return settings.ORGANIZATION_NAME
+
+
 class EndorsementEmailService:
     """Service for sending endorsement-related emails"""
 
@@ -110,7 +124,7 @@ class EndorsementEmailService:
                     "campaign": endorsement.campaign,
                     "verification_url": verification_url,
                     "site_url": settings.SITE_URL,
-                    "organization_name": settings.ORGANIZATION_NAME,
+                    "organization_name": _organization_name(),
                 },
                 recipients=[endorsement.stakeholder.email],
                 description=f"verification email for endorsement {endorsement.id}",
@@ -145,7 +159,7 @@ class EndorsementEmailService:
                         f"{settings.API_URL}/admin/endorsements/endorsement/"
                         f"{endorsement.id}/change/"
                     ),
-                    "organization_name": settings.ORGANIZATION_NAME,
+                    "organization_name": _organization_name(),
                 },
                 recipients=recipients,
                 description=f"admin notification for endorsement {endorsement.id}",
@@ -169,7 +183,7 @@ class EndorsementEmailService:
                     "campaign_url": (
                         f"{settings.SITE_URL}/campaigns/{endorsement.campaign.name}/"
                     ),
-                    "organization_name": settings.ORGANIZATION_NAME,
+                    "organization_name": _organization_name(),
                 },
                 recipients=[endorsement.stakeholder.email],
                 description=f"approval confirmation for endorsement {endorsement.id}",

--- a/backend/coalition/endorsements/email_service.py
+++ b/backend/coalition/endorsements/email_service.py
@@ -109,6 +109,9 @@ class EndorsementEmailService:
 
         Returns True if the message was accepted for delivery.
         """
+        endorsement.verification_sent_at = timezone.now()
+        endorsement.save(update_fields=["verification_sent_at"])
+
         verification_url = (
             f"{settings.SITE_URL}/verify-endorsement/{endorsement.verification_token}/"
         )
@@ -131,8 +134,8 @@ class EndorsementEmailService:
             ),
         )
 
-        if delivered:
-            endorsement.verification_sent_at = timezone.now()
+        if not delivered:
+            endorsement.verification_sent_at = None
             endorsement.save(update_fields=["verification_sent_at"])
 
         return delivered

--- a/backend/coalition/endorsements/email_service.py
+++ b/backend/coalition/endorsements/email_service.py
@@ -107,7 +107,9 @@ class EndorsementEmailService:
 
         Returns True if the message was accepted for delivery.
         """
-        endorsement.verification_sent_at = timezone.now()
+        previous_sent_at = endorsement.verification_sent_at
+        attempt_sent_at = timezone.now()
+        endorsement.verification_sent_at = attempt_sent_at
         endorsement.save(update_fields=["verification_sent_at"])
 
         verification_url = (
@@ -132,8 +134,14 @@ class EndorsementEmailService:
         )
 
         if not delivered:
-            endorsement.verification_sent_at = None
-            endorsement.save(update_fields=["verification_sent_at"])
+            restored = Endorsement.objects.filter(
+                pk=endorsement.pk,
+                verification_sent_at=attempt_sent_at,
+            ).update(verification_sent_at=previous_sent_at)
+            if restored:
+                endorsement.verification_sent_at = previous_sent_at
+            else:
+                endorsement.refresh_from_db(fields=["verification_sent_at"])
 
         return delivered
 

--- a/backend/coalition/endorsements/tests/test_email_service.py
+++ b/backend/coalition/endorsements/tests/test_email_service.py
@@ -8,6 +8,7 @@ from unittest.mock import Mock, patch
 from botocore.exceptions import ClientError
 from django.core import mail
 from django.core.exceptions import ImproperlyConfigured
+from django.db import OperationalError
 from django.template.exceptions import TemplateDoesNotExist
 
 from coalition.campaigns.models import PolicyCampaign
@@ -61,6 +62,23 @@ class EndorsementEmailServiceTest(BaseTestCase):
         # Check that timestamp was updated
         self.endorsement.refresh_from_db()
         assert self.endorsement.verification_sent_at is not None
+
+    @patch("coalition.endorsements.email_service.send_mail")
+    def test_timestamp_is_persisted_before_verification_email_is_sent(
+        self,
+        mock_send_mail: Mock,
+    ) -> None:
+        with (
+            patch.object(
+                self.endorsement,
+                "save",
+                side_effect=OperationalError("database unavailable"),
+            ),
+            self.assertRaises(OperationalError),
+        ):
+            EndorsementEmailService.send_verification_email(self.endorsement)
+
+        mock_send_mail.assert_not_called()
 
     def test_verification_email_uses_active_homepage_organization_name(self) -> None:
         HomePage.objects.create(

--- a/backend/coalition/endorsements/tests/test_email_service.py
+++ b/backend/coalition/endorsements/tests/test_email_service.py
@@ -11,6 +11,7 @@ from django.core.exceptions import ImproperlyConfigured
 from django.template.exceptions import TemplateDoesNotExist
 
 from coalition.campaigns.models import PolicyCampaign
+from coalition.content.models import HomePage
 from coalition.test_base import BaseTestCase
 
 from ..email_service import EndorsementEmailService
@@ -60,6 +61,21 @@ class EndorsementEmailServiceTest(BaseTestCase):
         # Check that timestamp was updated
         self.endorsement.refresh_from_db()
         assert self.endorsement.verification_sent_at is not None
+
+    def test_verification_email_uses_active_homepage_organization_name(self) -> None:
+        HomePage.objects.create(
+            organization_name="Land and Bay Stewards",
+            tagline="Stewarding land and bay",
+            hero_title="Land and Bay Stewards",
+        )
+        mail.outbox = []
+
+        with self.settings(ORGANIZATION_NAME="Coalition Builder"):
+            sent = EndorsementEmailService.send_verification_email(self.endorsement)
+
+        assert sent is True
+        assert "Land and Bay Stewards" in mail.outbox[0].body
+        assert "Coalition Builder" not in mail.outbox[0].body
 
     @patch("coalition.endorsements.email_service.send_mail")
     def test_send_verification_email_failure(self, mock_send_mail: Mock) -> None:

--- a/backend/coalition/endorsements/tests/test_email_service.py
+++ b/backend/coalition/endorsements/tests/test_email_service.py
@@ -2,6 +2,7 @@
 Tests for endorsement email service functionality.
 """
 
+from datetime import timedelta
 from smtplib import SMTPException
 from unittest.mock import Mock, patch
 
@@ -10,6 +11,7 @@ from django.core import mail
 from django.core.exceptions import ImproperlyConfigured
 from django.db import OperationalError
 from django.template.exceptions import TemplateDoesNotExist
+from django.utils import timezone
 
 from coalition.campaigns.models import PolicyCampaign
 from coalition.content.models import HomePage
@@ -79,6 +81,47 @@ class EndorsementEmailServiceTest(BaseTestCase):
             EndorsementEmailService.send_verification_email(self.endorsement)
 
         mock_send_mail.assert_not_called()
+
+    @patch("coalition.endorsements.email_service.send_mail")
+    def test_failed_resend_preserves_previous_sent_timestamp(
+        self,
+        mock_send_mail: Mock,
+    ) -> None:
+        mock_send_mail.return_value = 1
+        EndorsementEmailService.send_verification_email(self.endorsement)
+        self.endorsement.refresh_from_db()
+        previous_sent_at = self.endorsement.verification_sent_at
+
+        mock_send_mail.return_value = 0
+        sent = EndorsementEmailService.send_verification_email(self.endorsement)
+
+        assert sent is False
+        self.endorsement.refresh_from_db()
+        assert self.endorsement.verification_sent_at == previous_sent_at
+
+    def test_failed_resend_does_not_overwrite_newer_concurrent_timestamp(
+        self,
+    ) -> None:
+        previous_sent_at = timezone.now() - timedelta(hours=1)
+        newer_sent_at = timezone.now() + timedelta(seconds=1)
+        self.endorsement.verification_sent_at = previous_sent_at
+        self.endorsement.save(update_fields=["verification_sent_at"])
+
+        def record_concurrent_success(_email: object) -> bool:
+            Endorsement.objects.filter(pk=self.endorsement.pk).update(
+                verification_sent_at=newer_sent_at,
+            )
+            return False
+
+        with patch(
+            "coalition.endorsements.email_service._deliver",
+            side_effect=record_concurrent_success,
+        ):
+            sent = EndorsementEmailService.send_verification_email(self.endorsement)
+
+        assert sent is False
+        self.endorsement.refresh_from_db()
+        assert self.endorsement.verification_sent_at == newer_sent_at
 
     def test_verification_email_uses_active_homepage_organization_name(self) -> None:
         HomePage.objects.create(

--- a/backend/coalition/endorsements/tests/test_email_service.py
+++ b/backend/coalition/endorsements/tests/test_email_service.py
@@ -95,6 +95,37 @@ class EndorsementEmailServiceTest(BaseTestCase):
         assert "Land and Bay Stewards" in mail.outbox[0].body
         assert "Coalition Builder" not in mail.outbox[0].body
 
+    def test_verification_email_uses_configured_name_without_homepage(self) -> None:
+        HomePage.objects.all().delete()
+        mail.outbox = []
+
+        with self.settings(ORGANIZATION_NAME="Configured Organization"):
+            sent = EndorsementEmailService.send_verification_email(self.endorsement)
+
+        assert sent is True
+        assert "Configured Organization" in mail.outbox[0].body
+
+    @patch(
+        "coalition.endorsements.email_service.HomePage.get_active",
+        side_effect=OperationalError("homepage lookup failed"),
+    )
+    def test_homepage_lookup_failure_prevents_wrong_brand_email(
+        self,
+        mock_get_active: Mock,
+    ) -> None:
+        mail.outbox = []
+
+        with self.assertLogs(
+            "coalition.endorsements.email_service",
+            level="ERROR",
+        ) as captured:
+            sent = EndorsementEmailService.send_verification_email(self.endorsement)
+
+        assert sent is False
+        assert mail.outbox == []
+        assert "EMAIL_DELIVERY_FAILED" in captured.output[0]
+        mock_get_active.assert_called_once_with()
+
     @patch("coalition.endorsements.email_service.send_mail")
     def test_send_verification_email_failure(self, mock_send_mail: Mock) -> None:
         """Test verification email sending failure"""

--- a/frontend/app/verify-endorsement/[token]/__tests__/page.test.tsx
+++ b/frontend/app/verify-endorsement/[token]/__tests__/page.test.tsx
@@ -1,0 +1,65 @@
+import React from "react";
+import { render, screen, waitFor } from "@testing-library/react";
+import API from "../../../../services/api";
+import VerifyEndorsementPage from "../page";
+
+jest.mock("../../../../services/api", () => ({
+  __esModule: true,
+  default: {
+    verifyEndorsement: jest.fn(),
+  },
+}));
+
+describe("VerifyEndorsementPage", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("verifies the token and confirms the endorsement is under review", async () => {
+    (API.verifyEndorsement as jest.Mock).mockResolvedValue({
+      success: true,
+      message:
+        "Email verified successfully! Your endorsement is now under review.",
+      status: "verified",
+    });
+
+    render(
+      <VerifyEndorsementPage
+        params={Promise.resolve({ token: "verification-token" })}
+      />
+    );
+
+    expect(screen.getByText("Verifying your endorsement…")).toBeInTheDocument();
+    await waitFor(() => {
+      expect(API.verifyEndorsement).toHaveBeenCalledWith("verification-token");
+    });
+    expect(
+      await screen.findByRole("heading", { name: "Endorsement verified" })
+    ).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: "Return home" })).toHaveAttribute(
+      "href",
+      "/"
+    );
+  });
+
+  it("shows a useful error when verification fails", async () => {
+    (API.verifyEndorsement as jest.Mock).mockRejectedValue(
+      new Error("HTTP error! status: 404")
+    );
+
+    render(
+      <VerifyEndorsementPage
+        params={Promise.resolve({ token: "missing-token" })}
+      />
+    );
+
+    expect(
+      await screen.findByRole("heading", { name: "Verification failed" })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        "This verification link is invalid or has expired. Please submit your endorsement again."
+      )
+    ).toBeInTheDocument();
+  });
+});

--- a/frontend/app/verify-endorsement/[token]/__tests__/page.test.tsx
+++ b/frontend/app/verify-endorsement/[token]/__tests__/page.test.tsx
@@ -42,6 +42,25 @@ describe("VerifyEndorsementPage", () => {
     );
   });
 
+  it("reports an auto-approved endorsement accurately", async () => {
+    (API.verifyEndorsement as jest.Mock).mockResolvedValue({
+      success: true,
+      message: "Email verified successfully",
+      status: "approved",
+    });
+
+    render(
+      <VerifyEndorsementPage
+        params={Promise.resolve({ token: "approved-token" })}
+      />
+    );
+
+    expect(
+      await screen.findByText("Thank you. Your endorsement has been approved.")
+    ).toBeInTheDocument();
+    expect(screen.queryByText(/under review/i)).not.toBeInTheDocument();
+  });
+
   it("shows a useful error when verification fails", async () => {
     (API.verifyEndorsement as jest.Mock).mockRejectedValue(
       new Error("HTTP error! status: 404")
@@ -58,6 +77,9 @@ describe("VerifyEndorsementPage", () => {
     ).toBeInTheDocument();
     expect(
       screen.getByText(/we could not verify your endorsement right now/i)
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(/contact the campaign organizers to request a new link/i)
     ).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Try again" })).toBeEnabled();
   });

--- a/frontend/app/verify-endorsement/[token]/__tests__/page.test.tsx
+++ b/frontend/app/verify-endorsement/[token]/__tests__/page.test.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { render, screen, waitFor } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import API from "../../../../services/api";
 import VerifyEndorsementPage from "../page";
 
@@ -57,9 +57,35 @@ describe("VerifyEndorsementPage", () => {
       await screen.findByRole("heading", { name: "Verification failed" })
     ).toBeInTheDocument();
     expect(
-      screen.getByText(
-        "This verification link is invalid or has expired. Please submit your endorsement again."
-      )
+      screen.getByText(/we could not verify your endorsement right now/i)
+    ).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Try again" })).toBeEnabled();
+  });
+
+  it("retries verification after a temporary failure", async () => {
+    (API.verifyEndorsement as jest.Mock)
+      .mockRejectedValueOnce(new Error("Network unavailable"))
+      .mockResolvedValueOnce({
+        success: true,
+        message:
+          "Email verified successfully! Your endorsement is now under review.",
+        status: "verified",
+      });
+
+    render(
+      <VerifyEndorsementPage
+        params={Promise.resolve({ token: "verification-token" })}
+      />
+    );
+
+    fireEvent.click(await screen.findByRole("button", { name: "Try again" }));
+
+    expect(screen.getByText("Verifying your endorsement…")).toBeInTheDocument();
+    await waitFor(() => {
+      expect(API.verifyEndorsement).toHaveBeenCalledTimes(2);
+    });
+    expect(
+      await screen.findByRole("heading", { name: "Endorsement verified" })
     ).toBeInTheDocument();
   });
 });

--- a/frontend/app/verify-endorsement/[token]/layout.tsx
+++ b/frontend/app/verify-endorsement/[token]/layout.tsx
@@ -1,0 +1,12 @@
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "Verify endorsement",
+  robots: "noindex, nofollow",
+};
+
+export default function VerifyEndorsementLayout({
+  children,
+}: Readonly<{ children: React.ReactNode }>) {
+  return children;
+}

--- a/frontend/app/verify-endorsement/[token]/page.tsx
+++ b/frontend/app/verify-endorsement/[token]/page.tsx
@@ -1,0 +1,89 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import Link from "next/link";
+import API from "../../../services/api";
+
+interface VerifyEndorsementPageProps {
+  params: Promise<{ token: string }>;
+}
+
+type VerificationState = "verifying" | "verified" | "failed";
+
+export default function VerifyEndorsementPage({
+  params,
+}: VerifyEndorsementPageProps) {
+  const [verificationState, setVerificationState] =
+    useState<VerificationState>("verifying");
+
+  useEffect(() => {
+    let isActive = true;
+
+    const verifyToken = async () => {
+      try {
+        const { token } = await params;
+        await API.verifyEndorsement(token);
+        if (isActive) {
+          setVerificationState("verified");
+        }
+      } catch {
+        if (isActive) {
+          setVerificationState("failed");
+        }
+      }
+    };
+
+    void verifyToken();
+    return () => {
+      isActive = false;
+    };
+  }, [params]);
+
+  return (
+    <section className="mx-auto max-w-2xl px-6 py-20 text-center">
+      {verificationState === "verifying" && (
+        <>
+          <h1 className="text-3xl font-bold text-gray-900">
+            Verifying your endorsement…
+          </h1>
+          <p className="mt-4 text-gray-600">This should only take a moment.</p>
+        </>
+      )}
+
+      {verificationState === "verified" && (
+        <>
+          <h1 className="text-3xl font-bold text-gray-900">
+            Endorsement verified
+          </h1>
+          <p className="mt-4 text-gray-600">
+            Thank you. Your endorsement is now under review.
+          </p>
+          <Link
+            href="/"
+            className="mt-8 inline-block rounded-md bg-blue-600 px-5 py-3 font-semibold text-white no-underline hover:bg-blue-700"
+          >
+            Return home
+          </Link>
+        </>
+      )}
+
+      {verificationState === "failed" && (
+        <>
+          <h1 className="text-3xl font-bold text-gray-900">
+            Verification failed
+          </h1>
+          <p className="mt-4 text-gray-600">
+            This verification link is invalid or has expired. Please submit your
+            endorsement again.
+          </p>
+          <Link
+            href="/campaigns"
+            className="mt-8 inline-block rounded-md bg-blue-600 px-5 py-3 font-semibold text-white no-underline hover:bg-blue-700"
+          >
+            View campaigns
+          </Link>
+        </>
+      )}
+    </section>
+  );
+}

--- a/frontend/app/verify-endorsement/[token]/page.tsx
+++ b/frontend/app/verify-endorsement/[token]/page.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useState } from "react";
 import Link from "next/link";
 import API from "../../../services/api";
+import type { EndorsementVerification } from "../../../types";
 
 interface VerifyEndorsementPageProps {
   params: Promise<{ token: string }>;
@@ -10,11 +11,26 @@ interface VerifyEndorsementPageProps {
 
 type VerificationState = "verifying" | "verified" | "failed";
 
+function verificationConfirmation(
+  status: EndorsementVerification["status"] | null
+): string {
+  if (status === "approved") {
+    return "Thank you. Your endorsement has been approved.";
+  }
+  if (status === "rejected") {
+    return "Your email is verified. This endorsement was not approved.";
+  }
+  return "Thank you. Your endorsement is now under review.";
+}
+
 export default function VerifyEndorsementPage({
   params,
 }: VerifyEndorsementPageProps) {
   const [verificationState, setVerificationState] =
     useState<VerificationState>("verifying");
+  const [verificationStatus, setVerificationStatus] = useState<
+    EndorsementVerification["status"] | null
+  >(null);
   const [verificationAttempt, setVerificationAttempt] = useState(0);
 
   useEffect(() => {
@@ -23,8 +39,9 @@ export default function VerifyEndorsementPage({
     const verifyToken = async () => {
       try {
         const { token } = await params;
-        await API.verifyEndorsement(token);
+        const verification = await API.verifyEndorsement(token);
         if (isActive) {
+          setVerificationStatus(verification.status);
           setVerificationState("verified");
         }
       } catch {
@@ -41,6 +58,7 @@ export default function VerifyEndorsementPage({
   }, [params, verificationAttempt]);
 
   const retryVerification = () => {
+    setVerificationStatus(null);
     setVerificationState("verifying");
     setVerificationAttempt((previousAttempt) => previousAttempt + 1);
   };
@@ -62,7 +80,7 @@ export default function VerifyEndorsementPage({
             Endorsement verified
           </h1>
           <p className="mt-4 text-gray-600">
-            Thank you. Your endorsement is now under review.
+            {verificationConfirmation(verificationStatus)}
           </p>
           <Link
             href="/"
@@ -80,8 +98,8 @@ export default function VerifyEndorsementPage({
           </h1>
           <p className="mt-4 text-gray-600">
             We could not verify your endorsement right now. Try again. If the
-            problem continues, return to the campaign and submit the form again
-            to request a new verification email.
+            problem continues, contact the campaign organizers to request a new
+            link.
           </p>
           <div className="mt-8 flex flex-wrap justify-center gap-4">
             <button

--- a/frontend/app/verify-endorsement/[token]/page.tsx
+++ b/frontend/app/verify-endorsement/[token]/page.tsx
@@ -15,6 +15,7 @@ export default function VerifyEndorsementPage({
 }: VerifyEndorsementPageProps) {
   const [verificationState, setVerificationState] =
     useState<VerificationState>("verifying");
+  const [verificationAttempt, setVerificationAttempt] = useState(0);
 
   useEffect(() => {
     let isActive = true;
@@ -37,7 +38,12 @@ export default function VerifyEndorsementPage({
     return () => {
       isActive = false;
     };
-  }, [params]);
+  }, [params, verificationAttempt]);
+
+  const retryVerification = () => {
+    setVerificationState("verifying");
+    setVerificationAttempt((previousAttempt) => previousAttempt + 1);
+  };
 
   return (
     <section className="mx-auto max-w-2xl px-6 py-20 text-center">
@@ -73,15 +79,25 @@ export default function VerifyEndorsementPage({
             Verification failed
           </h1>
           <p className="mt-4 text-gray-600">
-            This verification link is invalid or has expired. Please submit your
-            endorsement again.
+            We could not verify your endorsement right now. Try again. If the
+            problem continues, return to the campaign and submit the form again
+            to request a new verification email.
           </p>
-          <Link
-            href="/campaigns"
-            className="mt-8 inline-block rounded-md bg-blue-600 px-5 py-3 font-semibold text-white no-underline hover:bg-blue-700"
-          >
-            View campaigns
-          </Link>
+          <div className="mt-8 flex flex-wrap justify-center gap-4">
+            <button
+              type="button"
+              className="rounded-md bg-blue-600 px-5 py-3 font-semibold text-white hover:bg-blue-700"
+              onClick={retryVerification}
+            >
+              Try again
+            </button>
+            <Link
+              href="/campaigns"
+              className="inline-block rounded-md border border-blue-600 px-5 py-3 font-semibold text-blue-700 no-underline hover:bg-blue-50"
+            >
+              View campaigns
+            </Link>
+          </div>
         </>
       )}
     </section>

--- a/frontend/components/EndorsementConfirmationDialog.tsx
+++ b/frontend/components/EndorsementConfirmationDialog.tsx
@@ -71,8 +71,8 @@ const EndorsementConfirmationDialog: React.FC<
         Thank you for your endorsement!
       </h3>
       <p>
-        Check your email and click the verification link. Your endorsement will
-        be sent for review after you verify it.
+        Check your email and click the verification link. Verifying your email
+        completes your submission.
       </p>
       <p>
         If the email does not arrive, you can request another copy without

--- a/frontend/components/EndorsementConfirmationDialog.tsx
+++ b/frontend/components/EndorsementConfirmationDialog.tsx
@@ -1,17 +1,22 @@
-import React, { useEffect, useRef } from "react";
+import React, { useEffect, useRef, useState } from "react";
+import API from "../services/api";
 import { Campaign } from "../types/index";
 import SocialShareButtons from "./SocialShareButtons";
 
 interface EndorsementConfirmationDialogProps {
   campaign: Campaign;
+  email: string;
   onClose: () => void;
   returnFocusTo: HTMLElement | null;
 }
 
 const EndorsementConfirmationDialog: React.FC<
   EndorsementConfirmationDialogProps
-> = ({ campaign, onClose, returnFocusTo }) => {
+> = ({ campaign, email, onClose, returnFocusTo }) => {
   const dialogRef = useRef<HTMLDialogElement>(null);
+  const [resendState, setResendState] = useState<
+    "idle" | "sending" | "sent" | "failed"
+  >("idle");
 
   useEffect(() => {
     const dialog = dialogRef.current;
@@ -33,6 +38,16 @@ const EndorsementConfirmationDialog: React.FC<
   const closeOnCancel = (event: React.SyntheticEvent<HTMLDialogElement>) => {
     event.preventDefault();
     onClose();
+  };
+
+  const requestAnotherVerificationEmail = async () => {
+    setResendState("sending");
+    try {
+      await API.resendEndorsementVerification(email, campaign.id);
+      setResendState("sent");
+    } catch {
+      setResendState("failed");
+    }
   };
 
   return (
@@ -60,9 +75,27 @@ const EndorsementConfirmationDialog: React.FC<
         be sent for review after you verify it.
       </p>
       <p>
-        If the email does not arrive, close this message and resubmit the form
-        to request another verification email.
+        If the email does not arrive, you can request another copy without
+        submitting the form again.
       </p>
+      <button
+        type="button"
+        className="confirmation-resend-button"
+        disabled={resendState === "sending" || resendState === "sent"}
+        onClick={requestAnotherVerificationEmail}
+      >
+        {resendState === "sending"
+          ? "Requesting verification email…"
+          : "Send another verification email"}
+      </button>
+      {resendState === "sent" && (
+        <p role="status">Another verification email has been requested.</p>
+      )}
+      {resendState === "failed" && (
+        <p role="alert">
+          We could not request another email. Please try again later.
+        </p>
+      )}
 
       <div className="share-endorsement-section">
         <p className="share-cta">

--- a/frontend/components/EndorsementConfirmationDialog.tsx
+++ b/frontend/components/EndorsementConfirmationDialog.tsx
@@ -59,6 +59,10 @@ const EndorsementConfirmationDialog: React.FC<
         Check your email and click the verification link. Your endorsement will
         be sent for review after you verify it.
       </p>
+      <p>
+        If the email does not arrive, close this message and resubmit the form
+        to request another verification email.
+      </p>
 
       <div className="share-endorsement-section">
         <p className="share-cta">

--- a/frontend/components/EndorsementConfirmationDialog.tsx
+++ b/frontend/components/EndorsementConfirmationDialog.tsx
@@ -1,0 +1,86 @@
+import React, { useEffect, useRef } from "react";
+import { Campaign } from "../types/index";
+import SocialShareButtons from "./SocialShareButtons";
+
+interface EndorsementConfirmationDialogProps {
+  campaign: Campaign;
+  onClose: () => void;
+  returnFocusTo: HTMLElement | null;
+}
+
+const EndorsementConfirmationDialog: React.FC<
+  EndorsementConfirmationDialogProps
+> = ({ campaign, onClose, returnFocusTo }) => {
+  const dialogRef = useRef<HTMLDialogElement>(null);
+
+  useEffect(() => {
+    const dialog = dialogRef.current;
+    const previouslyFocusedElement = returnFocusTo ?? document.activeElement;
+
+    dialog?.showModal();
+
+    return () => {
+      if (dialog?.open) {
+        dialog.close();
+      }
+
+      if (previouslyFocusedElement instanceof HTMLElement) {
+        previouslyFocusedElement.focus();
+      }
+    };
+  }, [returnFocusTo]);
+
+  const closeOnCancel = (event: React.SyntheticEvent<HTMLDialogElement>) => {
+    event.preventDefault();
+    onClose();
+  };
+
+  return (
+    <dialog
+      ref={dialogRef}
+      className="success-message confirmation-dialog"
+      data-testid="success-message"
+      aria-labelledby="endorsement-confirmation-title"
+      onCancel={closeOnCancel}
+    >
+      <button
+        type="button"
+        className="confirmation-dialog-close"
+        aria-label="Close confirmation"
+        onClick={onClose}
+        autoFocus
+      >
+        ×
+      </button>
+      <h3 id="endorsement-confirmation-title">
+        Thank you for your endorsement!
+      </h3>
+      <p>
+        Check your email and click the verification link. Your endorsement will
+        be sent for review after you verify it.
+      </p>
+
+      <div className="share-endorsement-section">
+        <p className="share-cta">
+          Help amplify your support by sharing this campaign:
+        </p>
+        <SocialShareButtons
+          url={`${window.location.origin}/campaigns/${campaign.name}`}
+          title={`I just endorsed ${campaign.title}!`}
+          description={`Join me in supporting this important initiative: ${
+            campaign.summary || campaign.description
+          }`}
+          hashtags={[
+            "PolicyChange",
+            "CivicEngagement",
+            campaign.name?.replace(/-/g, "") || "",
+          ]}
+          campaignName={campaign.name}
+          showLabel={false}
+        />
+      </div>
+    </dialog>
+  );
+};
+
+export default EndorsementConfirmationDialog;

--- a/frontend/components/EndorsementForm.tsx
+++ b/frontend/components/EndorsementForm.tsx
@@ -1,5 +1,4 @@
 import React, {
-  useEffect,
   useState,
   useRef,
   forwardRef,
@@ -8,8 +7,8 @@ import React, {
 import API from "../services/api";
 import analytics from "../services/analytics";
 import { Campaign, EndorsementCreate, Stakeholder } from "../types/index";
-import SocialShareButtons from "./SocialShareButtons";
 import AddressAutocomplete from "./AddressAutocomplete";
+import EndorsementConfirmationDialog from "./EndorsementConfirmationDialog";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faPaperPlane } from "@fortawesome/free-solid-svg-icons";
 import "../styles/Endorsements.css";
@@ -119,13 +118,7 @@ const EndorsementForm = forwardRef<EndorsementFormRef, EndorsementFormProps>(
     });
     const formRef = useRef<HTMLFormElement>(null);
     const typeSelectRef = useRef<HTMLSelectElement>(null);
-    const confirmationCloseRef = useRef<HTMLButtonElement>(null);
-
-    useEffect(() => {
-      if (success) {
-        confirmationCloseRef.current?.focus();
-      }
-    }, [success]);
+    const submitButtonRef = useRef<HTMLButtonElement>(null);
 
     // Expose methods to parent component
     useImperativeHandle(
@@ -315,57 +308,11 @@ const EndorsementForm = forwardRef<EndorsementFormRef, EndorsementFormProps>(
         )}
 
         {success && (
-          <div className="confirmation-dialog-backdrop">
-            <div
-              className="success-message confirmation-dialog"
-              data-testid="success-message"
-              role="dialog"
-              aria-modal="true"
-              aria-labelledby="endorsement-confirmation-title"
-              onKeyDown={(event) => {
-                if (event.key === "Escape") {
-                  setSuccess(false);
-                }
-              }}
-            >
-              <button
-                ref={confirmationCloseRef}
-                type="button"
-                className="confirmation-dialog-close"
-                aria-label="Close confirmation"
-                onClick={() => setSuccess(false)}
-              >
-                ×
-              </button>
-              <h3 id="endorsement-confirmation-title">
-                Thank you for your endorsement!
-              </h3>
-              <p>
-                Check your email and click the verification link. Your
-                endorsement will be sent for review after you verify it.
-              </p>
-
-              <div className="share-endorsement-section">
-                <p className="share-cta">
-                  Help amplify your support by sharing this campaign:
-                </p>
-                <SocialShareButtons
-                  url={`${window.location.origin}/campaigns/${campaign.name}`}
-                  title={`I just endorsed ${campaign.title}!`}
-                  description={`Join me in supporting this important initiative: ${
-                    campaign.summary || campaign.description
-                  }`}
-                  hashtags={[
-                    "PolicyChange",
-                    "CivicEngagement",
-                    campaign.name?.replace(/-/g, "") || "",
-                  ]}
-                  campaignName={campaign.name}
-                  showLabel={false}
-                />
-              </div>
-            </div>
-          </div>
+          <EndorsementConfirmationDialog
+            campaign={campaign}
+            onClose={() => setSuccess(false)}
+            returnFocusTo={submitButtonRef.current}
+          />
         )}
 
         {error && (
@@ -747,6 +694,7 @@ const EndorsementForm = forwardRef<EndorsementFormRef, EndorsementFormProps>(
 
           <div className="form-actions">
             <button
+              ref={submitButtonRef}
               type="submit"
               disabled={isSubmitting}
               data-testid="submit-button"

--- a/frontend/components/EndorsementForm.tsx
+++ b/frontend/components/EndorsementForm.tsx
@@ -107,6 +107,9 @@ const EndorsementForm = forwardRef<EndorsementFormRef, EndorsementFormProps>(
     const [isSubmitting, setIsSubmitting] = useState<boolean>(false);
     const [error, setError] = useState<string | null>(null);
     const [success, setSuccess] = useState<boolean>(false);
+    const [confirmationEmail, setConfirmationEmail] = useState<string | null>(
+      null
+    );
 
     // Spam prevention state
     const [formStartTime] = useState<string>(new Date().toISOString());
@@ -208,6 +211,7 @@ const EndorsementForm = forwardRef<EndorsementFormRef, EndorsementFormProps>(
         };
 
         await API.createEndorsement(endorsementData);
+        setConfirmationEmail(stakeholder.email);
         setSuccess(true);
 
         // Track successful endorsement submission
@@ -307,10 +311,14 @@ const EndorsementForm = forwardRef<EndorsementFormRef, EndorsementFormProps>(
           </div>
         )}
 
-        {success && (
+        {success && confirmationEmail && (
           <EndorsementConfirmationDialog
             campaign={campaign}
-            onClose={() => setSuccess(false)}
+            email={confirmationEmail}
+            onClose={() => {
+              setSuccess(false);
+              setConfirmationEmail(null);
+            }}
             returnFocusTo={submitButtonRef.current}
           />
         )}

--- a/frontend/components/EndorsementForm.tsx
+++ b/frontend/components/EndorsementForm.tsx
@@ -1,4 +1,5 @@
 import React, {
+  useEffect,
   useState,
   useRef,
   forwardRef,
@@ -118,6 +119,13 @@ const EndorsementForm = forwardRef<EndorsementFormRef, EndorsementFormProps>(
     });
     const formRef = useRef<HTMLFormElement>(null);
     const typeSelectRef = useRef<HTMLSelectElement>(null);
+    const confirmationCloseRef = useRef<HTMLButtonElement>(null);
+
+    useEffect(() => {
+      if (success) {
+        confirmationCloseRef.current?.focus();
+      }
+    }, [success]);
 
     // Expose methods to parent component
     useImperativeHandle(
@@ -307,31 +315,55 @@ const EndorsementForm = forwardRef<EndorsementFormRef, EndorsementFormProps>(
         )}
 
         {success && (
-          <div className="success-message" data-testid="success-message">
-            <h3>Thank you for your endorsement!</h3>
-            <p>
-              Your endorsement has been submitted successfully and will be
-              reviewed shortly.
-            </p>
-
-            <div className="share-endorsement-section">
-              <p className="share-cta">
-                Help amplify your support by sharing this campaign:
+          <div className="confirmation-dialog-backdrop">
+            <div
+              className="success-message confirmation-dialog"
+              data-testid="success-message"
+              role="dialog"
+              aria-modal="true"
+              aria-labelledby="endorsement-confirmation-title"
+              onKeyDown={(event) => {
+                if (event.key === "Escape") {
+                  setSuccess(false);
+                }
+              }}
+            >
+              <button
+                ref={confirmationCloseRef}
+                type="button"
+                className="confirmation-dialog-close"
+                aria-label="Close confirmation"
+                onClick={() => setSuccess(false)}
+              >
+                ×
+              </button>
+              <h3 id="endorsement-confirmation-title">
+                Thank you for your endorsement!
+              </h3>
+              <p>
+                Check your email and click the verification link. Your
+                endorsement will be sent for review after you verify it.
               </p>
-              <SocialShareButtons
-                url={`${window.location.origin}/campaigns/${campaign.name}`}
-                title={`I just endorsed ${campaign.title}!`}
-                description={`Join me in supporting this important initiative: ${
-                  campaign.summary || campaign.description
-                }`}
-                hashtags={[
-                  "PolicyChange",
-                  "CivicEngagement",
-                  campaign.name?.replace(/-/g, "") || "",
-                ]}
-                campaignName={campaign.name}
-                showLabel={false}
-              />
+
+              <div className="share-endorsement-section">
+                <p className="share-cta">
+                  Help amplify your support by sharing this campaign:
+                </p>
+                <SocialShareButtons
+                  url={`${window.location.origin}/campaigns/${campaign.name}`}
+                  title={`I just endorsed ${campaign.title}!`}
+                  description={`Join me in supporting this important initiative: ${
+                    campaign.summary || campaign.description
+                  }`}
+                  hashtags={[
+                    "PolicyChange",
+                    "CivicEngagement",
+                    campaign.name?.replace(/-/g, "") || "",
+                  ]}
+                  campaignName={campaign.name}
+                  showLabel={false}
+                />
+              </div>
             </div>
           </div>
         )}

--- a/frontend/components/__tests__/EndorsementForm.test.tsx
+++ b/frontend/components/__tests__/EndorsementForm.test.tsx
@@ -318,6 +318,9 @@ describe("EndorsementForm", () => {
       expect(
         screen.getByRole("button", { name: "Send another verification email" })
       ).toBeEnabled();
+      expect(
+        screen.getByText(/verifying your email completes your submission/i)
+      ).toBeInTheDocument();
 
       const confirmationDialog = screen.getByRole("dialog");
       expect(confirmationDialog.tagName).toBe("DIALOG");

--- a/frontend/components/__tests__/EndorsementForm.test.tsx
+++ b/frontend/components/__tests__/EndorsementForm.test.tsx
@@ -309,6 +309,9 @@ describe("EndorsementForm", () => {
           screen.getByText("Thank you for your endorsement!")
         ).toBeInTheDocument();
       });
+      expect(
+        screen.getByText(/resubmit the form to request another verification/i)
+      ).toBeInTheDocument();
 
       const confirmationDialog = screen.getByRole("dialog");
       expect(confirmationDialog.tagName).toBe("DIALOG");

--- a/frontend/components/__tests__/EndorsementForm.test.tsx
+++ b/frontend/components/__tests__/EndorsementForm.test.tsx
@@ -71,6 +71,18 @@ jest.mock("../../services/api", () => ({
 }));
 jest.mock("../../services/analytics");
 
+const showModalMock = jest.fn(function (this: HTMLDialogElement) {
+  this.open = true;
+});
+const closeDialogMock = jest.fn(function (this: HTMLDialogElement) {
+  this.open = false;
+});
+
+Object.defineProperties(HTMLDialogElement.prototype, {
+  showModal: { configurable: true, value: showModalMock },
+  close: { configurable: true, value: closeDialogMock },
+});
+
 // Mock SocialShareButtons component
 jest.mock("../SocialShareButtons", () => {
   return function MockSocialShareButtons(props: {
@@ -298,7 +310,9 @@ describe("EndorsementForm", () => {
         ).toBeInTheDocument();
       });
 
-      expect(screen.getByRole("dialog")).toHaveAttribute("aria-modal", "true");
+      const confirmationDialog = screen.getByRole("dialog");
+      expect(confirmationDialog.tagName).toBe("DIALOG");
+      expect(showModalMock).toHaveBeenCalledTimes(1);
 
       // Check that social share buttons are displayed
       expect(screen.getByTestId("social-share-buttons")).toBeInTheDocument();
@@ -324,7 +338,8 @@ describe("EndorsementForm", () => {
       });
       await fillAddressFields();
       fireEvent.click(screen.getByTestId("terms-checkbox"));
-      fireEvent.click(screen.getByTestId("submit-button"));
+      const submitButton = screen.getByTestId("submit-button");
+      fireEvent.click(submitButton);
 
       await waitFor(() =>
         expect(screen.getByRole("dialog")).toBeInTheDocument()
@@ -334,6 +349,8 @@ describe("EndorsementForm", () => {
       );
 
       expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+      expect(closeDialogMock).toHaveBeenCalledTimes(1);
+      expect(submitButton).toHaveFocus();
       expect(API.createEndorsement).toHaveBeenCalledTimes(1);
     });
 

--- a/frontend/components/__tests__/EndorsementForm.test.tsx
+++ b/frontend/components/__tests__/EndorsementForm.test.tsx
@@ -19,6 +19,7 @@ jest.mock("../../services/api", () => ({
     getEndorsements: jest.fn(),
     getCampaignEndorsements: jest.fn(),
     createEndorsement: jest.fn(),
+    resendEndorsementVerification: jest.fn(),
     getHomepageById: jest.fn(),
     getContentBlocks: jest.fn(),
     getContentBlocksByPageType: jest.fn(),
@@ -196,6 +197,11 @@ describe("EndorsementForm", () => {
       campaign_id: 1,
       stakeholder_id: 1,
     });
+    (API.resendEndorsementVerification as jest.Mock).mockResolvedValue({
+      success: true,
+      message:
+        "If an endorsement exists for this email and campaign, a verification email has been sent.",
+    });
   });
 
   it("handles honeypot field changes", () => {
@@ -310,8 +316,8 @@ describe("EndorsementForm", () => {
         ).toBeInTheDocument();
       });
       expect(
-        screen.getByText(/resubmit the form to request another verification/i)
-      ).toBeInTheDocument();
+        screen.getByRole("button", { name: "Send another verification email" })
+      ).toBeEnabled();
 
       const confirmationDialog = screen.getByRole("dialog");
       expect(confirmationDialog.tagName).toBe("DIALOG");
@@ -322,6 +328,43 @@ describe("EndorsementForm", () => {
       expect(
         screen.getByText("Help amplify your support by sharing this campaign:")
       ).toBeInTheDocument();
+    });
+
+    it("requests another verification email without resubmitting", async () => {
+      render(<EndorsementForm campaign={mockCampaign} />);
+
+      fireEvent.change(screen.getByTestId("type-select"), {
+        target: { value: "individual" },
+      });
+      fireEvent.change(screen.getByTestId("first-name-input"), {
+        target: { value: "John" },
+      });
+      fireEvent.change(screen.getByTestId("last-name-input"), {
+        target: { value: "Doe" },
+      });
+      fireEvent.change(screen.getByTestId("email-input"), {
+        target: { value: "john@example.com" },
+      });
+      await fillAddressFields();
+      fireEvent.click(screen.getByTestId("terms-checkbox"));
+      fireEvent.click(screen.getByTestId("submit-button"));
+
+      fireEvent.click(
+        await screen.findByRole("button", {
+          name: "Send another verification email",
+        })
+      );
+
+      await waitFor(() => {
+        expect(API.resendEndorsementVerification).toHaveBeenCalledWith(
+          "john@example.com",
+          mockCampaign.id
+        );
+      });
+      expect(
+        screen.getByText(/another verification email has been requested/i)
+      ).toBeInTheDocument();
+      expect(API.createEndorsement).toHaveBeenCalledTimes(1);
     });
 
     it("closes the confirmation dialog without resubmitting", async () => {

--- a/frontend/components/__tests__/EndorsementForm.test.tsx
+++ b/frontend/components/__tests__/EndorsementForm.test.tsx
@@ -298,11 +298,43 @@ describe("EndorsementForm", () => {
         ).toBeInTheDocument();
       });
 
+      expect(screen.getByRole("dialog")).toHaveAttribute("aria-modal", "true");
+
       // Check that social share buttons are displayed
       expect(screen.getByTestId("social-share-buttons")).toBeInTheDocument();
       expect(
         screen.getByText("Help amplify your support by sharing this campaign:")
       ).toBeInTheDocument();
+    });
+
+    it("closes the confirmation dialog without resubmitting", async () => {
+      render(<EndorsementForm campaign={mockCampaign} />);
+
+      fireEvent.change(screen.getByTestId("type-select"), {
+        target: { value: "individual" },
+      });
+      fireEvent.change(screen.getByTestId("first-name-input"), {
+        target: { value: "John" },
+      });
+      fireEvent.change(screen.getByTestId("last-name-input"), {
+        target: { value: "Doe" },
+      });
+      fireEvent.change(screen.getByTestId("email-input"), {
+        target: { value: "john@example.com" },
+      });
+      await fillAddressFields();
+      fireEvent.click(screen.getByTestId("terms-checkbox"));
+      fireEvent.click(screen.getByTestId("submit-button"));
+
+      await waitFor(() =>
+        expect(screen.getByRole("dialog")).toBeInTheDocument()
+      );
+      fireEvent.click(
+        screen.getByRole("button", { name: "Close confirmation" })
+      );
+
+      expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+      expect(API.createEndorsement).toHaveBeenCalledTimes(1);
     });
 
     it("passes correct props to SocialShareButtons component", async () => {

--- a/frontend/services/__tests__/api-client.test.ts
+++ b/frontend/services/__tests__/api-client.test.ts
@@ -244,6 +244,25 @@ describe("BaseApiClient", () => {
     });
   });
 
+  describe("verifyEndorsement", () => {
+    it("should verify an endorsement token", async () => {
+      const verification = {
+        success: true,
+        message: "Email verified successfully",
+        status: "verified" as const,
+      };
+      client.requestMock.mockResolvedValue(verification);
+
+      const result = await client.verifyEndorsement("token/with spaces");
+
+      expect(result).toEqual(verification);
+      expect(client.requestMock).toHaveBeenCalledWith(
+        "/api/endorsements/verify/token%2Fwith%20spaces/",
+        { method: "POST" }
+      );
+    });
+  });
+
   describe("getHomepage", () => {
     it("should fetch homepage", async () => {
       const mockHomepage: HomePage = {

--- a/frontend/services/__tests__/api-post-methods.test.ts
+++ b/frontend/services/__tests__/api-post-methods.test.ts
@@ -85,6 +85,37 @@ describeInCI("API Service - POST/PATCH Methods", () => {
     });
   });
 
+  describe("verifyEndorsement", () => {
+    it("posts the verification token with CSRF protection", async () => {
+      document.cookie = "csrftoken=verification-csrf-token";
+      const verification = {
+        success: true,
+        message: "Email verified successfully",
+        status: "verified",
+      };
+      mockFetch.mockResolvedValueOnce(createMockResponse(verification));
+
+      const result = await API.verifyEndorsement("verification-token");
+
+      expect(result).toEqual(verification);
+      expect(mockFetch).toHaveBeenCalledWith(
+        getExpectedUrl(
+          "/api/endorsements/verify/verification-token/",
+          originalEnv
+        ),
+        expect.objectContaining({
+          method: "POST",
+          credentials: "same-origin",
+          headers: expect.objectContaining({
+            "Content-Type": "application/json",
+            "x-csrftoken": "verification-csrf-token",
+          }),
+          signal: expect.any(AbortSignal),
+        })
+      );
+    });
+  });
+
   describe("patch method", () => {
     it("should support PATCH requests", async () => {
       const mockData = { id: 1, name: "Updated" };

--- a/frontend/services/__tests__/api-post-methods.test.ts
+++ b/frontend/services/__tests__/api-post-methods.test.ts
@@ -116,6 +116,40 @@ describeInCI("API Service - POST/PATCH Methods", () => {
     });
   });
 
+  describe("resendEndorsementVerification", () => {
+    it("posts the email and campaign with CSRF protection", async () => {
+      document.cookie = "csrftoken=resend-csrf-token";
+      const resendResponse = {
+        success: true,
+        message: "A verification email has been requested.",
+      };
+      mockFetch.mockResolvedValueOnce(createMockResponse(resendResponse));
+
+      const result = await API.resendEndorsementVerification(
+        "john@example.com",
+        7
+      );
+
+      expect(result).toEqual(resendResponse);
+      expect(mockFetch).toHaveBeenCalledWith(
+        getExpectedUrl("/api/endorsements/resend-verification/", originalEnv),
+        expect.objectContaining({
+          method: "POST",
+          body: JSON.stringify({
+            email: "john@example.com",
+            campaign_id: 7,
+          }),
+          credentials: "same-origin",
+          headers: expect.objectContaining({
+            "Content-Type": "application/json",
+            "x-csrftoken": "resend-csrf-token",
+          }),
+          signal: expect.any(AbortSignal),
+        })
+      );
+    });
+  });
+
   describe("patch method", () => {
     it("should support PATCH requests", async () => {
       const mockData = { id: 1, name: "Updated" };

--- a/frontend/services/api-client.ts
+++ b/frontend/services/api-client.ts
@@ -12,6 +12,7 @@ import type {
   Legislator,
   Endorsement,
   EndorsementCreate,
+  EndorsementVerification,
 } from "../types";
 
 export interface ApiClientConfig {
@@ -86,6 +87,13 @@ export abstract class BaseApiClient {
       },
       body: JSON.stringify(endorsementData),
     });
+  }
+
+  async verifyEndorsement(token: string): Promise<EndorsementVerification> {
+    return this.request<EndorsementVerification>(
+      `/api/endorsements/verify/${encodeURIComponent(token)}/`,
+      { method: "POST" }
+    );
   }
 
   async getHomepage(): Promise<HomePage> {

--- a/frontend/services/api.ts
+++ b/frontend/services/api.ts
@@ -2,7 +2,11 @@
 // Extends the shared base client with browser-specific functionality like CSRF
 
 import { BaseApiClient } from "./api-client";
-import type { Endorsement, EndorsementCreate } from "../types";
+import type {
+  Endorsement,
+  EndorsementCreate,
+  EndorsementVerification,
+} from "../types";
 
 export function getBaseUrl(): string {
   // For browser context, always use relative URLs to avoid CORS
@@ -310,6 +314,12 @@ class FrontendApiClient extends BaseApiClient {
     endorsementData: EndorsementCreate
   ): Promise<Endorsement> {
     return this.post<Endorsement>("/api/endorsements/", endorsementData);
+  }
+
+  async verifyEndorsement(token: string): Promise<EndorsementVerification> {
+    return this.post<EndorsementVerification>(
+      `/api/endorsements/verify/${encodeURIComponent(token)}/`
+    );
   }
 }
 

--- a/frontend/services/api.ts
+++ b/frontend/services/api.ts
@@ -6,6 +6,7 @@ import type {
   Endorsement,
   EndorsementCreate,
   EndorsementVerification,
+  EndorsementVerificationResend,
 } from "../types";
 
 export function getBaseUrl(): string {
@@ -319,6 +320,16 @@ class FrontendApiClient extends BaseApiClient {
   async verifyEndorsement(token: string): Promise<EndorsementVerification> {
     return this.post<EndorsementVerification>(
       `/api/endorsements/verify/${encodeURIComponent(token)}/`
+    );
+  }
+
+  async resendEndorsementVerification(
+    email: string,
+    campaignId: number
+  ): Promise<EndorsementVerificationResend> {
+    return this.post<EndorsementVerificationResend>(
+      "/api/endorsements/resend-verification/",
+      { email, campaign_id: campaignId }
     );
   }
 }

--- a/frontend/styles/Endorsements.css
+++ b/frontend/styles/Endorsements.css
@@ -1256,6 +1256,21 @@ legend.form-label {
   outline-offset: 2px;
 }
 
+.confirmation-resend-button {
+  border: 1px solid currentcolor;
+  border-radius: 0.375rem;
+  padding: 0.625rem 1rem;
+  background: transparent;
+  color: inherit;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.confirmation-resend-button:disabled {
+  cursor: default;
+  opacity: 0.65;
+}
+
 .success-message {
   background-color: #d4edda;
   border: 1px solid #c3e6cb;

--- a/frontend/styles/Endorsements.css
+++ b/frontend/styles/Endorsements.css
@@ -1226,22 +1226,17 @@ legend.form-label {
 }
 
 /* Success Message */
-.confirmation-dialog-backdrop {
-  position: fixed;
-  inset: 0;
-  z-index: 1000;
-  display: grid;
-  place-items: center;
-  padding: 1rem;
-  background: rgba(15, 23, 42, 0.65);
-}
-
 .confirmation-dialog {
   position: relative;
-  width: min(36rem, 100%);
+  width: min(36rem, calc(100% - 2rem));
   max-height: calc(100vh - 2rem);
   overflow-y: auto;
+  box-sizing: border-box;
   box-shadow: 0 24px 60px rgba(15, 23, 42, 0.35);
+}
+
+.confirmation-dialog::backdrop {
+  background: rgba(15, 23, 42, 0.65);
 }
 
 .confirmation-dialog-close {

--- a/frontend/styles/Endorsements.css
+++ b/frontend/styles/Endorsements.css
@@ -1226,6 +1226,41 @@ legend.form-label {
 }
 
 /* Success Message */
+.confirmation-dialog-backdrop {
+  position: fixed;
+  inset: 0;
+  z-index: 1000;
+  display: grid;
+  place-items: center;
+  padding: 1rem;
+  background: rgba(15, 23, 42, 0.65);
+}
+
+.confirmation-dialog {
+  position: relative;
+  width: min(36rem, 100%);
+  max-height: calc(100vh - 2rem);
+  overflow-y: auto;
+  box-shadow: 0 24px 60px rgba(15, 23, 42, 0.35);
+}
+
+.confirmation-dialog-close {
+  position: absolute;
+  top: 0.5rem;
+  right: 0.75rem;
+  border: 0;
+  background: transparent;
+  color: inherit;
+  font-size: 1.75rem;
+  line-height: 1;
+  cursor: pointer;
+}
+
+.confirmation-dialog-close:focus-visible {
+  outline: 2px solid currentcolor;
+  outline-offset: 2px;
+}
+
 .success-message {
   background-color: #d4edda;
   border: 1px solid #c3e6cb;

--- a/frontend/types/api.ts
+++ b/frontend/types/api.ts
@@ -147,6 +147,11 @@ export interface EndorsementVerification {
   status: "pending" | "verified" | "approved" | "rejected";
 }
 
+export interface EndorsementVerificationResend {
+  success: boolean;
+  message: string;
+}
+
 // Theme and styling types
 export interface Theme {
   id: number;

--- a/frontend/types/api.ts
+++ b/frontend/types/api.ts
@@ -141,6 +141,12 @@ export interface EndorsementCreate {
   form_metadata?: SpamPreventionMetadata;
 }
 
+export interface EndorsementVerification {
+  success: boolean;
+  message: string;
+  status: "pending" | "verified" | "approved" | "rejected";
+}
+
 // Theme and styling types
 export interface Theme {
   id: number;


### PR DESCRIPTION
## What changed

- Show an accessible confirmation dialog immediately after a successful endorsement submission, with accurate instructions to verify by email.
- Add the missing `/verify-endorsement/<token>/` frontend route and submit verification tokens to the existing backend endpoint with CSRF protection.
- Persist endorsements before sending verification and admin-notification emails, and contain unexpected notification failures so they cannot invalidate a completed submission.
- Source endorsement-email branding from the active homepage configuration, falling back to the Django setting only when no homepage exists.

## Root cause

The form rendered its success message above a long form, leaving it outside the viewport after submission. Verification emails linked to a frontend route that did not exist, and the shared API method did not provide the browser-specific CSRF handling needed by Django. Email branding used `settings.ORGANIZATION_NAME`, which fell back to "Coalition Builder" in production even though the active homepage identifies the organization as "Land and Bay Stewards". Email delivery also happened inside the database transaction, coupling external notification failures to submission persistence.

## Impact

Endorsers now receive an immediate confirmation, can complete verification from the emailed link, and see the correct organization name in endorsement emails. Notification failures are logged without rolling back a valid endorsement.

## Validation

- Backend endorsement API and email suites: 58 passed.
- Focused frontend form, verification-page, and API-client suites: 40 passed.
- Ruff format and lint passed.
- Mypy passed for the changed backend modules.
- TypeScript, ESLint, and Prettier passed.

## Accepted risks

- Two overlapping failed verification-email resends can extend an existing token's expiry by up to 24 hours. The token does not become indefinite; the frontend prevents repeated resend clicks and the backend rate-limits requests by IP. Strict confirmed-delivery semantics require persisted per-attempt delivery state and are intentionally out of scope for this PR.