### PR TITLE
fix(endorsements): improve admin status contrast

### DIFF
--- a/backend/coalition/endorsements/admin.py
+++ b/backend/coalition/endorsements/admin.py
@@ -154,17 +154,21 @@ class EndorsementAdmin(HelpLinkAdminMixin, admin.ModelAdmin):
 
     @admin.display(description="Status", ordering="status")
     def status_badge(self, obj: Endorsement) -> str:
-        colors = {
-            "pending": "#ffc107",  # warning yellow
-            "verified": "#17a2b8",  # info blue
-            "approved": "#28a745",  # success green
-            "rejected": "#dc3545",  # danger red
+        color_schemes = {
+            "pending": ("#ffc107", "#212529"),  # warning yellow
+            "verified": ("#17a2b8", "#212529"),  # info blue
+            "approved": ("#28a745", "#212529"),  # success green
+            "rejected": ("#dc3545", "white"),  # danger red
         }
-        color = colors.get(obj.status, "#6c757d")
+        background_color, text_color = color_schemes.get(
+            obj.status,
+            ("#6c757d", "white"),
+        )
         return format_html(
-            '<span style="background-color: {}; color: white; padding: 2px 8px; '
+            '<span style="background-color: {}; color: {}; padding: 2px 8px; '
             'border-radius: 3px; font-size: 11px;">{}</span>',
-            color,
+            background_color,
+            text_color,
             obj.get_status_display(),
         )
 

--- a/backend/coalition/endorsements/tests/css_accessibility.py
+++ b/backend/coalition/endorsements/tests/css_accessibility.py
@@ -1,0 +1,43 @@
+def parse_inline_styles(markup: str) -> dict[str, str]:
+    _, separator, markup_after_style = markup.partition('style="')
+    if not separator:
+        raise AssertionError("Expected rendered markup to include an inline style")
+
+    style_attribute, _, _ = markup_after_style.partition('"')
+    declarations = (
+        declaration.split(":", maxsplit=1)
+        for declaration in style_attribute.split(";")
+        if declaration.strip()
+    )
+    return {
+        property_name.strip(): property_value.strip()
+        for property_name, property_value in declarations
+    }
+
+
+def contrast_ratio(first_color: str, second_color: str) -> float:
+    lighter, darker = sorted(
+        (_relative_luminance(first_color), _relative_luminance(second_color)),
+        reverse=True,
+    )
+    return (lighter + 0.05) / (darker + 0.05)
+
+
+def _relative_luminance(css_color: str) -> float:
+    hex_color = "#ffffff" if css_color.lower() == "white" else css_color
+    if len(hex_color) != 7 or not hex_color.startswith("#"):
+        raise AssertionError(f"Unsupported CSS color: {css_color}")
+
+    channels = [int(hex_color[index : index + 2], 16) / 255 for index in (1, 3, 5)]
+    linear_channels = [
+        channel / 12.92 if channel <= 0.04045 else ((channel + 0.055) / 1.055) ** 2.4
+        for channel in channels
+    ]
+    return sum(
+        coefficient * channel
+        for coefficient, channel in zip(
+            (0.2126, 0.7152, 0.0722),
+            linear_channels,
+            strict=True,
+        )
+    )

--- a/backend/coalition/endorsements/tests/test_admin.py
+++ b/backend/coalition/endorsements/tests/test_admin.py
@@ -62,11 +62,22 @@ class EndorsementAdminTest(BaseTestCase):
         result = self.admin.stakeholder_organization(self.endorsement)
         assert result == "Test Org"
 
-    def test_status_badge_method(self) -> None:
-        """Test status_badge admin method"""
-        result = self.admin.status_badge(self.endorsement)
-        assert "pending" in result.lower()
-        assert "background-color" in result
+    def test_status_badge_uses_readable_text_color(self) -> None:
+        expected_text_colors = {
+            "pending": "#212529",
+            "verified": "#212529",
+            "approved": "#212529",
+            "rejected": "white",
+        }
+
+        for status, text_color in expected_text_colors.items():
+            with self.subTest(status=status):
+                self.endorsement.status = status
+
+                badge = self.admin.status_badge(self.endorsement)
+
+                assert self.endorsement.get_status_display() in badge
+                assert f"color: {text_color}" in badge
 
     def test_email_verified_badge_method(self) -> None:
         """Test email_verified_badge admin method"""

--- a/backend/coalition/endorsements/tests/test_admin.py
+++ b/backend/coalition/endorsements/tests/test_admin.py
@@ -16,6 +16,7 @@ from coalition.test_base import BaseTestCase
 from ..admin import EndorsementAdmin
 from ..email_service import EndorsementEmailService
 from ..models import Endorsement
+from .css_accessibility import contrast_ratio, parse_inline_styles
 
 
 class EndorsementAdminTest(BaseTestCase):
@@ -63,21 +64,22 @@ class EndorsementAdminTest(BaseTestCase):
         assert result == "Test Org"
 
     def test_status_badge_uses_readable_text_color(self) -> None:
-        expected_text_colors = {
-            "pending": "#212529",
-            "verified": "#212529",
-            "approved": "#212529",
-            "rejected": "white",
-        }
+        rendered_backgrounds = set()
 
-        for status, text_color in expected_text_colors.items():
+        for status, _ in Endorsement.STATUS_CHOICES:
             with self.subTest(status=status):
                 self.endorsement.status = status
 
                 badge = self.admin.status_badge(self.endorsement)
+                style_declarations = parse_inline_styles(badge)
+                background_color = style_declarations["background-color"]
+                text_color = style_declarations["color"]
+                rendered_backgrounds.add(background_color)
 
                 assert self.endorsement.get_status_display() in badge
-                assert f"color: {text_color}" in badge
+                assert contrast_ratio(background_color, text_color) >= 4.5
+
+        assert len(rendered_backgrounds) == len(Endorsement.STATUS_CHOICES)
 
     def test_email_verified_badge_method(self) -> None:
         """Test email_verified_badge admin method"""


### PR DESCRIPTION
## Summary

- Give each endorsement status badge a foreground color that maintains readable contrast with its background.
- Add regression coverage for every supported endorsement status.

## Why

The admin badge renderer always used white text, which produced insufficient contrast on the yellow pending badge shown in the endorsement list and similarly weak contrast on the blue and green variants.

## Impact

Endorsement statuses are easier to read in the Django admin while retaining the existing status colors. All foreground/background pairs now meet WCAG AA contrast for normal-sized text.

## Validation

- `ruff format --check backend/coalition/endorsements/admin.py backend/coalition/endorsements/tests/test_admin.py`
- `ruff check backend/coalition/endorsements/admin.py backend/coalition/endorsements/tests/test_admin.py`
- `pytest coalition/endorsements/tests/test_admin.py --no-cov` (25 passed)