### PR TITLE
Remove static SES SMTP credentials now that Lambda sends via the execution role

### DIFF
--- a/.github/workflows/test_terraform.yml
+++ b/.github/workflows/test_terraform.yml
@@ -45,6 +45,8 @@ jobs:
           terraform -chdir=terraform/modules/github-oidc test
           terraform -chdir=terraform/modules/zappa init -backend=false -input=false
           terraform -chdir=terraform/modules/zappa test
+          terraform -chdir=terraform/modules/ses init -backend=false -input=false
+          terraform -chdir=terraform/modules/ses test
 
   # Run all tests (unit tests don't need AWS, integration tests do)
   tests:

--- a/docs/email-configuration.md
+++ b/docs/email-configuration.md
@@ -16,7 +16,7 @@ The Terraform configuration automates the production SES path across the SES, ne
 4. **Lambda Authorization** - Grants the execution role scoped SES send permissions
 5. **Private Connectivity** - Adds the SES API interface VPC endpoint
 6. **Monitoring** - Alarms on application-level delivery failures and publishes SES notifications
-7. **Legacy SMTP Credentials** - Retains credentials for non-Lambda deployments
+7. **Optional SMTP Credentials** - Supports credentials for non-Lambda deployments without provisioning them for Lambda
 
 ### Enable SES in Terraform
 
@@ -37,7 +37,7 @@ The module will:
 - Authorize configured Lambda sender roles to call the SES API
 - Add an SES API VPC endpoint when `enable_ses_endpoint` is enabled
 - Configure delivery-failure monitoring and SES notifications
-- Retain SMTP credentials in Secrets Manager for deployment targets that still use `SafeSMTPBackend`; Lambda does not consume them
+- Provision SMTP credentials in Secrets Manager only when `create_smtp_credentials = true`; the setting defaults to `true` for compatibility, while production Lambda explicitly disables it
 
 ## AWS SES Setup
 
@@ -76,7 +76,16 @@ To request production access:
 
 ### 3. Create SMTP Credentials for Non-Lambda Deployments
 
-Lambda does not need SMTP credentials. For a non-Lambda deployment using `SafeSMTPBackend`, create them manually if Terraform does not manage them:
+Lambda does not need SMTP credentials, and the production Terraform environment sets `create_smtp_credentials = false`. For a non-Lambda deployment using `SafeSMTPBackend`, either retain the module default or set the option explicitly:
+
+```hcl
+module "ses" {
+  # Other SES settings omitted.
+  create_smtp_credentials = true
+}
+```
+
+This creates an IAM user and access key, derives the SES SMTP password, and stores only the SMTP connection fields in `<prefix>/ses-smtp-credentials`. Alternatively, create credentials manually when Terraform should not manage a long-lived key:
 
 ```bash
 # In AWS Console -> SES -> SMTP settings -> Create SMTP credentials
@@ -84,7 +93,7 @@ Lambda does not need SMTP credentials. For a non-Lambda deployment using `SafeSM
 # Save the SMTP username and password securely
 ```
 
-The SMTP password is automatically calculated by Terraform using the included Python script.
+When enabled, Terraform calculates the SMTP password using the included Python script.
 
 ### 4. Configure SMTP Environment Variables
 
@@ -214,19 +223,23 @@ poetry run zappa invoke prod \
 ### Common Issues
 
 1. **"Email address is not verified"**
+
    - You're in sandbox mode and trying to send to unverified address
    - Solution: Verify the recipient or request production access
 
 2. **"Connection timeout" or a request that hangs until the Lambda times out**
+
    - The task cannot reach the SES endpoint. On Lambda this means the SES interface VPC endpoint is missing: the private subnets have no NAT and no default route, so the connection never completes rather than failing fast.
    - Solution: set `enable_ses_endpoint = true` for the environment. Confirm with `socket.gethostbyname("email.<region>.amazonaws.com")` from inside the function — it must return a private VPC address, not a public one.
    - For non-Lambda deployments, ensure the task has internet egress.
 
 3. **"Invalid credentials"**
+
    - SMTP credentials are incorrect
    - Solution: Regenerate SMTP credentials in SES console. On Lambda this error should not occur at all — it authenticates with the execution role, so check `sender_role_names` and the `ses:FromAddress` condition instead.
 
 4. **"Email address is not verified" for ordinary users**
+
    - The account is still in the SES sandbox, which only permits verified recipients. Sending to your own verified domain succeeds while every real endorser is rejected, so this can look like a partial outage.
    - Solution: request production access (see "Move Out of Sandbox" above), then confirm with `aws sesv2 get-account --query ProductionAccessEnabled`.
 

--- a/docs/email-configuration.md
+++ b/docs/email-configuration.md
@@ -223,23 +223,19 @@ poetry run zappa invoke prod \
 ### Common Issues
 
 1. **"Email address is not verified"**
-
    - You're in sandbox mode and trying to send to unverified address
    - Solution: Verify the recipient or request production access
 
 2. **"Connection timeout" or a request that hangs until the Lambda times out**
-
    - The task cannot reach the SES endpoint. On Lambda this means the SES interface VPC endpoint is missing: the private subnets have no NAT and no default route, so the connection never completes rather than failing fast.
    - Solution: set `enable_ses_endpoint = true` for the environment. Confirm with `socket.gethostbyname("email.<region>.amazonaws.com")` from inside the function — it must return a private VPC address, not a public one.
    - For non-Lambda deployments, ensure the task has internet egress.
 
 3. **"Invalid credentials"**
-
    - SMTP credentials are incorrect
    - Solution: Regenerate SMTP credentials in SES console. On Lambda this error should not occur at all — it authenticates with the execution role, so check `sender_role_names` and the `ses:FromAddress` condition instead.
 
 4. **"Email address is not verified" for ordinary users**
-
    - The account is still in the SES sandbox, which only permits verified recipients. Sending to your own verified domain succeeds while every real endorser is rejected, so this can look like a partial outage.
    - Solution: request production access (see "Move Out of Sandbox" above), then confirm with `aws sesv2 get-account --query ProductionAccessEnabled`.
 

--- a/terraform/LOCAL_DEPLOYMENT.md
+++ b/terraform/LOCAL_DEPLOYMENT.md
@@ -72,7 +72,7 @@ Type `yes` when prompted to confirm.
   - `/<prefix>/database-url` in each application account
   - `/<prefix>/secret-key`
   - `/<prefix>/site-password`
-  - `/<prefix>/ses-smtp-credentials`
+  - `/<prefix>/ses-smtp-credentials` when the SES module's `create_smtp_credentials` option is enabled
 
 SSM database URL parameters are retired. Secrets Manager is the only active runtime secrets path.
 

--- a/terraform/environments/prod/main.tf
+++ b/terraform/environments/prod/main.tf
@@ -190,15 +190,16 @@ module "monitoring" {
 module "ses" {
   source = "../../modules/ses"
 
-  prefix                 = var.prefix
-  aws_region             = var.aws_region
-  domain_name            = var.domain_name
-  from_email             = var.ses_from_email
-  verify_domain          = true
-  create_route53_records = false
-  dmarc_email            = var.ses_notification_email
-  notification_email     = var.ses_notification_email
-  enable_notifications   = true
+  prefix                  = var.prefix
+  aws_region              = var.aws_region
+  domain_name             = var.domain_name
+  from_email              = var.ses_from_email
+  verify_domain           = true
+  create_route53_records  = false
+  dmarc_email             = var.ses_notification_email
+  notification_email      = var.ses_notification_email
+  enable_notifications    = true
+  create_smtp_credentials = false
 
   # Lambda sends through the SES API with its execution role, so it needs no
   # static SMTP credentials.

--- a/terraform/modules/ses/README.md
+++ b/terraform/modules/ses/README.md
@@ -88,7 +88,6 @@ When `create_smtp_credentials` is enabled, this is handled automatically by the 
 ## Manual Steps Required
 
 1. **Request Production Access**:
-
    - New SES accounts start in sandbox mode
    - Request production access in AWS Console → SES → Account dashboard
    - Takes ~24 hours for approval

--- a/terraform/modules/ses/README.md
+++ b/terraform/modules/ses/README.md
@@ -7,9 +7,9 @@ This module configures AWS Simple Email Service (SES) for sending transactional 
 - **Automatic Domain Verification** - Verifies your domain with Route53 integration
 - **DKIM Configuration** - Sets up DKIM records for email authentication
 - **SPF & DMARC Records** - Configures email authentication records
-- **SMTP Credentials** - Automatically generates and stores SMTP credentials
-- **Password Calculation** - Automatically calculates SES SMTP password from IAM secret
-- **Secrets Management** - Stores credentials in AWS Secrets Manager
+- **Optional SMTP Credentials** - Generates credentials for non-role-based deployments when enabled
+- **Password Calculation** - Calculates the SES SMTP password from the IAM secret when credentials are enabled
+- **Secrets Management** - Stores only SMTP connection fields in AWS Secrets Manager
 - **Monitoring** - SNS notifications for bounces and complaints
 
 ## Usage
@@ -22,6 +22,7 @@ module "ses" {
   aws_region           = var.aws_region
   domain_name          = var.domain_name
   from_email           = "noreply@yourdomain.com"
+  create_smtp_credentials = true
   verify_domain        = true
   route53_zone_id      = var.route53_zone_id
   notification_email   = "admin@yourdomain.com"
@@ -31,40 +32,42 @@ module "ses" {
 
 ## Variables
 
-| Name                   | Description                                    | Type     | Default | Required |
-| ---------------------- | ---------------------------------------------- | -------- | ------- | -------- |
-| `prefix`               | Prefix for resource names                      | `string` | -       | yes      |
-| `aws_region`           | AWS region                                     | `string` | -       | yes      |
-| `domain_name`          | Domain name for sending emails                 | `string` | -       | yes      |
-| `from_email`           | Default from email address                     | `string` | -       | yes      |
-| `verify_domain`        | Whether to verify the entire domain            | `bool`   | `true`  | no       |
-| `verify_email`         | Whether to verify individual email (fallback)  | `bool`   | `false` | no       |
-| `route53_zone_id`      | Route53 zone ID for automatic DNS verification | `string` | `""`    | no       |
-| `create_spf_record`    | Whether to create SPF record                   | `bool`   | `true`  | no       |
-| `create_dmarc_record`  | Whether to create DMARC record                 | `bool`   | `true`  | no       |
-| `dmarc_email`          | Email for DMARC reports                        | `string` | `""`    | no       |
-| `enable_notifications` | Enable SNS notifications for SES events        | `bool`   | `true`  | no       |
-| `notification_email`   | Email for receiving SES notifications          | `string` | `""`    | no       |
+| Name                      | Description                                      | Type           | Default | Required |
+| ------------------------- | ------------------------------------------------ | -------------- | ------- | -------- |
+| `prefix`                  | Prefix for resource names                        | `string`       | -       | yes      |
+| `aws_region`              | AWS region                                       | `string`       | -       | yes      |
+| `domain_name`             | Domain name for sending emails                   | `string`       | -       | yes      |
+| `from_email`              | Default from email address                       | `string`       | -       | yes      |
+| `create_smtp_credentials` | Whether to create long-lived SMTP credentials    | `bool`         | `true`  | no       |
+| `verify_domain`           | Whether to verify the entire domain              | `bool`         | `true`  | no       |
+| `verify_email`            | Whether to verify individual email (fallback)    | `bool`         | `false` | no       |
+| `route53_zone_id`         | Route53 zone ID for automatic DNS verification   | `string`       | `""`    | no       |
+| `create_spf_record`       | Whether to create SPF record                     | `bool`         | `true`  | no       |
+| `create_dmarc_record`     | Whether to create DMARC record                   | `bool`         | `true`  | no       |
+| `dmarc_email`             | Email for DMARC reports                          | `string`       | `""`    | no       |
+| `enable_notifications`    | Enable SNS notifications for SES events          | `bool`         | `true`  | no       |
+| `notification_email`      | Email for receiving SES notifications            | `string`       | `""`    | no       |
+| `sender_role_names`       | IAM roles granted role-based SES API send access | `list(string)` | `[]`    | no       |
 
 ## Outputs
 
-| Name                   | Description                                                   |
-| ---------------------- | ------------------------------------------------------------- |
-| `ses_smtp_secret_arn`  | ARN of the Secrets Manager secret containing SMTP credentials |
-| `ses_smtp_secret_name` | Name of the Secrets Manager secret                            |
-| `ses_domain_identity`  | The verified SES domain identity                              |
-| `ses_smtp_username`    | SMTP username (sensitive)                                     |
-| `smtp_endpoint`        | SES SMTP endpoint                                             |
-| `smtp_port`            | SES SMTP port (587)                                           |
+| Name                   | Description                                      |
+| ---------------------- | ------------------------------------------------ |
+| `ses_smtp_secret_arn`  | ARN of the optional Secrets Manager SMTP secret  |
+| `ses_smtp_secret_name` | Name of the optional Secrets Manager SMTP secret |
+| `ses_domain_identity`  | The verified SES domain identity                 |
+| `ses_smtp_username`    | Optional SMTP username (sensitive)               |
+| `smtp_endpoint`        | SES SMTP endpoint                                |
+| `smtp_port`            | SES SMTP port (587)                              |
 
 ## How It Works
 
 1. **Domain Verification**: If `route53_zone_id` is provided, the module automatically creates verification records
 2. **DKIM Setup**: Creates three CNAME records for DKIM signing
-3. **IAM User Creation**: Creates an IAM user with SES sending permissions
-4. **Password Calculation**: Uses a Python script to calculate the SMTP password from the IAM secret key
-5. **Secret Storage**: Stores all credentials in AWS Secrets Manager
-6. **ECS Integration**: The compute module pulls these secrets and injects them into containers
+3. **Role Authorization**: Grants configured `sender_role_names` permission to send through the SES API
+4. **Optional IAM User Creation**: When `create_smtp_credentials` is true, creates an IAM user with SES sending permissions
+5. **Optional Password Calculation**: Uses a Python script to calculate the SMTP password from the IAM secret key
+6. **Optional Secret Storage**: Stores the SMTP connection fields in AWS Secrets Manager
 
 ## SMTP Password Calculation
 
@@ -80,11 +83,12 @@ signature = hmac.new(
 smtp_password = base64.b64encode(b'\x04' + signature).decode('utf-8')
 ```
 
-This is handled automatically by the `calculate_ses_password.py` script.
+When `create_smtp_credentials` is enabled, this is handled automatically by the `calculate_ses_password.py` script.
 
 ## Manual Steps Required
 
 1. **Request Production Access**:
+
    - New SES accounts start in sandbox mode
    - Request production access in AWS Console → SES → Account dashboard
    - Takes ~24 hours for approval

--- a/terraform/modules/ses/main.tf
+++ b/terraform/modules/ses/main.tf
@@ -67,6 +67,8 @@ resource "aws_ses_email_identity" "main" {
 
 # IAM user for SMTP credentials
 resource "aws_iam_user" "ses_smtp" {
+  count = var.create_smtp_credentials ? 1 : 0
+
   name = "${var.prefix}-ses-smtp-user"
   path = "/ses/"
 
@@ -77,13 +79,17 @@ resource "aws_iam_user" "ses_smtp" {
 
 # IAM access key for SMTP user
 resource "aws_iam_access_key" "ses_smtp" {
-  user = aws_iam_user.ses_smtp.name
+  count = var.create_smtp_credentials ? 1 : 0
+
+  user = aws_iam_user.ses_smtp[0].name
 }
 
 # IAM policy for SES sending
 resource "aws_iam_user_policy" "ses_smtp" {
+  count = var.create_smtp_credentials ? 1 : 0
+
   name = "${var.prefix}-ses-smtp-policy"
-  user = aws_iam_user.ses_smtp.name
+  user = aws_iam_user.ses_smtp[0].name
 
   policy = jsonencode({
     Version = "2012-10-17"
@@ -96,7 +102,7 @@ resource "aws_iam_user_policy" "ses_smtp" {
         ]
         Resource = "*"
         Condition = {
-          StringEquals = {
+          StringLike = {
             "ses:FromAddress" = var.verify_domain ? ["*@${var.domain_name}", var.from_email] : [var.from_email]
           }
         }
@@ -145,25 +151,26 @@ resource "aws_iam_role_policy_attachment" "ses_send" {
 
 # Calculate SES SMTP password using external data source
 data "external" "smtp_password" {
+  count = var.create_smtp_credentials ? 1 : 0
+
   program = ["python3", "${path.module}/scripts/calculate_ses_password.py"]
 
   query = {
-    secret_key = aws_iam_access_key.ses_smtp.secret
+    secret_key = aws_iam_access_key.ses_smtp[0].secret
     region     = var.aws_region
   }
 }
 
 # Convert IAM credentials to SES SMTP password
 locals {
-  # For SMTP username, use the access key ID directly
-  smtp_username = aws_iam_access_key.ses_smtp.id
-
-  # The calculated SMTP password from the external data source
-  smtp_password = data.external.smtp_password.result.value
+  smtp_username = one(aws_iam_access_key.ses_smtp[*].id)
+  smtp_password = one(data.external.smtp_password[*].result.value)
 }
 
 # Store SMTP credentials in Secrets Manager
 resource "aws_secretsmanager_secret" "ses_smtp" {
+  count = var.create_smtp_credentials ? 1 : 0
+
   name                    = "${var.prefix}/ses-smtp-credentials"
   description             = "SES SMTP credentials for ${var.prefix}"
   recovery_window_in_days = var.secret_recovery_days
@@ -242,7 +249,9 @@ resource "aws_sns_topic_subscription" "ses_email" {
 
 # Store credentials in Secrets Manager with calculated SMTP password
 resource "aws_secretsmanager_secret_version" "ses_smtp" {
-  secret_id = aws_secretsmanager_secret.ses_smtp.id
+  count = var.create_smtp_credentials ? 1 : 0
+
+  secret_id = aws_secretsmanager_secret.ses_smtp[0].id
   secret_string = jsonencode({
     EMAIL_HOST          = "email-smtp.${var.aws_region}.amazonaws.com"
     EMAIL_PORT          = "587"
@@ -250,8 +259,5 @@ resource "aws_secretsmanager_secret_version" "ses_smtp" {
     EMAIL_HOST_USER     = local.smtp_username
     EMAIL_HOST_PASSWORD = local.smtp_password
     DEFAULT_FROM_EMAIL  = var.from_email
-    # Also store raw IAM credentials if needed for SDK
-    AWS_ACCESS_KEY_ID     = aws_iam_access_key.ses_smtp.id
-    AWS_SECRET_ACCESS_KEY = aws_iam_access_key.ses_smtp.secret
   })
 }

--- a/terraform/modules/ses/outputs.tf
+++ b/terraform/modules/ses/outputs.tf
@@ -1,11 +1,11 @@
 output "ses_smtp_secret_arn" {
   description = "ARN of the Secrets Manager secret containing SMTP credentials"
-  value       = aws_secretsmanager_secret.ses_smtp.arn
+  value       = one(aws_secretsmanager_secret.ses_smtp[*].arn)
 }
 
 output "ses_smtp_secret_name" {
   description = "Name of the Secrets Manager secret containing SMTP credentials"
-  value       = aws_secretsmanager_secret.ses_smtp.name
+  value       = one(aws_secretsmanager_secret.ses_smtp[*].name)
 }
 
 output "ses_domain_identity" {
@@ -25,7 +25,7 @@ output "ses_dkim_tokens" {
 
 output "ses_smtp_username" {
   description = "SMTP username for SES"
-  value       = aws_iam_access_key.ses_smtp.id
+  value       = one(aws_iam_access_key.ses_smtp[*].id)
   sensitive   = true
 }
 

--- a/terraform/modules/ses/tests/smtp_credentials.tftest.hcl
+++ b/terraform/modules/ses/tests/smtp_credentials.tftest.hcl
@@ -1,0 +1,87 @@
+mock_provider "aws" {}
+
+mock_provider "external" {
+  override_data {
+    target = data.external.smtp_password
+    values = {
+      result = {
+        value = "mock-smtp-password"
+      }
+    }
+  }
+}
+
+variables {
+  prefix               = "example"
+  aws_region           = "us-east-1"
+  domain_name          = "example.org"
+  from_email           = "admin@example.org"
+  verify_domain        = true
+  enable_notifications = false
+}
+
+# #310: SMTP credentials remain available by default for non-Lambda deployments.
+run "smtp_credentials_are_created_by_default" {
+  command = apply
+
+  assert {
+    condition = alltrue([
+      length(aws_iam_user.ses_smtp) == 1,
+      length(aws_iam_access_key.ses_smtp) == 1,
+      length(aws_iam_user_policy.ses_smtp) == 1,
+      length(data.external.smtp_password) == 1,
+      length(aws_secretsmanager_secret.ses_smtp) == 1,
+      length(aws_secretsmanager_secret_version.ses_smtp) == 1,
+    ])
+    error_message = "SMTP credentials must remain enabled by default for existing module callers."
+  }
+
+  assert {
+    condition = alltrue([
+      contains(
+        jsondecode(aws_iam_user_policy.ses_smtp[0].policy).Statement[0].Condition.StringLike["ses:FromAddress"],
+        "*@example.org"
+      ),
+      !can(jsondecode(aws_iam_user_policy.ses_smtp[0].policy).Statement[0].Condition.StringEquals),
+    ])
+    error_message = "The SMTP user policy must use StringLike so its domain wildcard matches real sender addresses."
+  }
+
+  assert {
+    condition = alltrue([
+      !contains(keys(jsondecode(aws_secretsmanager_secret_version.ses_smtp[0].secret_string)), "AWS_ACCESS_KEY_ID"),
+      !contains(keys(jsondecode(aws_secretsmanager_secret_version.ses_smtp[0].secret_string)), "AWS_SECRET_ACCESS_KEY"),
+    ])
+    error_message = "The SMTP secret must not expose raw IAM access key credentials."
+  }
+}
+
+# #310: Lambda deployments can disable every long-lived SMTP credential resource.
+run "smtp_credentials_can_be_disabled" {
+  command = plan
+
+  variables {
+    create_smtp_credentials = false
+  }
+
+  assert {
+    condition = alltrue([
+      length(aws_iam_user.ses_smtp) == 0,
+      length(aws_iam_access_key.ses_smtp) == 0,
+      length(aws_iam_user_policy.ses_smtp) == 0,
+      length(data.external.smtp_password) == 0,
+      length(aws_secretsmanager_secret.ses_smtp) == 0,
+      length(aws_secretsmanager_secret_version.ses_smtp) == 0,
+    ])
+    error_message = "Disabling SMTP credentials must remove the IAM user, access key, policy, password lookup, secret, and secret version."
+  }
+
+  assert {
+    condition = alltrue([
+      output.ses_smtp_secret_arn == null,
+      output.ses_smtp_secret_name == null,
+      output.ses_smtp_username == null,
+    ])
+    error_message = "SMTP credential outputs must be null when credential creation is disabled."
+  }
+}

--- a/terraform/modules/ses/tests/smtp_credentials.tftest.hcl
+++ b/terraform/modules/ses/tests/smtp_credentials.tftest.hcl
@@ -1,4 +1,11 @@
-mock_provider "aws" {}
+mock_provider "aws" {
+  override_resource {
+    target = aws_iam_access_key.ses_smtp
+    values = {
+      id = "AKIAEXAMPLE"
+    }
+  }
+}
 
 mock_provider "external" {
   override_data {
@@ -48,11 +55,15 @@ run "smtp_credentials_are_created_by_default" {
   }
 
   assert {
-    condition = alltrue([
-      !contains(keys(jsondecode(aws_secretsmanager_secret_version.ses_smtp[0].secret_string)), "AWS_ACCESS_KEY_ID"),
-      !contains(keys(jsondecode(aws_secretsmanager_secret_version.ses_smtp[0].secret_string)), "AWS_SECRET_ACCESS_KEY"),
-    ])
-    error_message = "The SMTP secret must not expose raw IAM access key credentials."
+    condition = jsondecode(aws_secretsmanager_secret_version.ses_smtp[0].secret_string) == {
+      DEFAULT_FROM_EMAIL  = "admin@example.org"
+      EMAIL_HOST          = "email-smtp.us-east-1.amazonaws.com"
+      EMAIL_HOST_PASSWORD = "mock-smtp-password"
+      EMAIL_HOST_USER     = "AKIAEXAMPLE"
+      EMAIL_PORT          = "587"
+      EMAIL_USE_TLS       = "True"
+    }
+    error_message = "The SMTP secret must contain exactly the connection fields required by non-Lambda deployments."
   }
 }
 

--- a/terraform/modules/ses/tests/smtp_credentials.tftest.hcl
+++ b/terraform/modules/ses/tests/smtp_credentials.tftest.hcl
@@ -73,6 +73,7 @@ run "smtp_credentials_can_be_disabled" {
 
   variables {
     create_smtp_credentials = false
+    sender_role_names       = ["example-zappa-deployment"]
   }
 
   assert {
@@ -94,5 +95,13 @@ run "smtp_credentials_can_be_disabled" {
       output.ses_smtp_username == null,
     ])
     error_message = "SMTP credential outputs must be null when credential creation is disabled."
+  }
+
+  assert {
+    condition = alltrue([
+      length(aws_iam_policy.ses_send) == 1,
+      length(aws_iam_role_policy_attachment.ses_send) == 1,
+    ])
+    error_message = "Disabling SMTP credentials must preserve role-based SES sending for Lambda."
   }
 }

--- a/terraform/modules/ses/variables.tf
+++ b/terraform/modules/ses/variables.tf
@@ -18,6 +18,12 @@ variable "from_email" {
   type        = string
 }
 
+variable "create_smtp_credentials" {
+  description = "Whether to create and store long-lived SES SMTP credentials"
+  type        = bool
+  default     = true
+}
+
 variable "verify_domain" {
   description = "Whether to verify the entire domain in SES"
   type        = bool

--- a/terraform/tests/go.mod
+++ b/terraform/tests/go.mod
@@ -15,6 +15,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.99.0
 	github.com/aws/aws-sdk-go-v2/service/sns v1.33.6
 	github.com/gruntwork-io/terratest v0.49.0
+	github.com/hashicorp/hcl/v2 v2.22.0
 	github.com/stretchr/testify v1.11.1
 )
 
@@ -64,7 +65,6 @@ require (
 	github.com/hashicorp/go-multierror v1.1.1 // indirect
 	github.com/hashicorp/go-safetemp v1.0.0 // indirect
 	github.com/hashicorp/go-version v1.7.0 // indirect
-	github.com/hashicorp/hcl/v2 v2.22.0 // indirect
 	github.com/hashicorp/terraform-json v0.23.0 // indirect
 	github.com/jackc/pgpassfile v1.0.0 // indirect
 	github.com/jackc/pgservicefile v0.0.0-20240606120523-5a60cdf6a761 // indirect

--- a/terraform/tests/modules/ses_test.go
+++ b/terraform/tests/modules/ses_test.go
@@ -3,14 +3,16 @@ package modules
 import (
 	"os"
 	"path/filepath"
-	"regexp"
 	"strings"
 	"testing"
 
 	"terraform-tests/common"
 
 	"github.com/gruntwork-io/terratest/modules/terraform"
+	"github.com/hashicorp/hcl/v2"
+	"github.com/hashicorp/hcl/v2/hclsyntax"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestSESModuleStructure(t *testing.T) {
@@ -18,13 +20,33 @@ func TestSESModuleStructure(t *testing.T) {
 }
 
 func TestProductionDisablesSESSMTPCredentials(t *testing.T) {
-	productionSource, err := os.ReadFile("../../environments/prod/main.tf")
-	assert.NoError(t, err)
+	const productionPath = "../../environments/prod/main.tf"
+	productionSource, err := os.ReadFile(productionPath)
+	require.NoError(t, err)
 
-	productionOptOut := regexp.MustCompile(
-		`(?s)module "ses" \{.*?create_smtp_credentials\s*=\s*false.*?\n\}`,
+	productionConfig, diagnostics := hclsyntax.ParseConfig(
+		productionSource,
+		productionPath,
+		hcl.InitialPos,
 	)
-	assert.Regexp(t, productionOptOut, string(productionSource))
+	require.False(t, diagnostics.HasErrors(), diagnostics.Error())
+	productionBody, isSyntaxBody := productionConfig.Body.(*hclsyntax.Body)
+	require.True(t, isSyntaxBody)
+
+	var sesModule *hclsyntax.Block
+	for _, block := range productionBody.Blocks {
+		if block.Type == "module" && len(block.Labels) == 1 && block.Labels[0] == "ses" {
+			sesModule = block
+			break
+		}
+	}
+	require.NotNil(t, sesModule)
+
+	credentialSetting, exists := sesModule.Body.Attributes["create_smtp_credentials"]
+	require.True(t, exists)
+	settingRange := credentialSetting.Expr.Range()
+	settingSource := productionSource[settingRange.Start.Byte:settingRange.End.Byte]
+	assert.Equal(t, "false", strings.TrimSpace(string(settingSource)))
 }
 
 func TestSESModulePlanCreatesExpectedResources(t *testing.T) {

--- a/terraform/tests/modules/ses_test.go
+++ b/terraform/tests/modules/ses_test.go
@@ -1,7 +1,9 @@
 package modules
 
 import (
+	"os"
 	"path/filepath"
+	"regexp"
 	"strings"
 	"testing"
 
@@ -13,6 +15,16 @@ import (
 
 func TestSESModuleStructure(t *testing.T) {
 	common.ValidateModuleStructure(t, "ses")
+}
+
+func TestProductionDisablesSESSMTPCredentials(t *testing.T) {
+	productionSource, err := os.ReadFile("../../environments/prod/main.tf")
+	assert.NoError(t, err)
+
+	productionOptOut := regexp.MustCompile(
+		`(?s)module "ses" \{.*?create_smtp_credentials\s*=\s*false.*?\n\}`,
+	)
+	assert.Regexp(t, productionOptOut, string(productionSource))
 }
 
 func TestSESModulePlanCreatesExpectedResources(t *testing.T) {


### PR DESCRIPTION
Closes #310

## Summary

- make SES SMTP credential creation optional while preserving the module default for non-Lambda callers
- disable long-lived SMTP credentials in production, where Lambda sends through the SES API execution role
- correct the retained SMTP sender policy wildcard and remove raw AWS access keys from the stored secret
- document the separate Lambda and non-Lambda email paths

## Validation

- `terraform -chdir=terraform/modules/ses test` — 7 passed
- `terraform -chdir=terraform/modules/ses validate`
- `terraform -chdir=terraform/environments/prod validate`
- `terraform fmt -check -recursive terraform`
- `tflint --chdir=terraform --recursive`
- scoped Prettier checks for modified Markdown files

## Operational follow-up

An authenticated production plan must confirm that only the obsolete SMTP IAM user, access key, inline policy, Secrets Manager secret, and secret version are destroyed. Applying that plan and confirming a live endorsement verification email remain deployment steps.

Any existing deployment that keeps `create_smtp_credentials = true` must include a one-time access-key rotation and consumer reload as an upgrade gate. Without rotation, the prior secret payload remains retrievable as `AWSPREVIOUS` with the still-valid raw IAM key.