### PR TITLE
fix(endorsements): make submitted fields read-only

### DIFF
--- a/backend/coalition/admin_help/content/reviewing-endorsements.md
+++ b/backend/coalition/admin_help/content/reviewing-endorsements.md
@@ -48,10 +48,10 @@ Click a row to open it. The form is grouped into sections:
   the Terms of Use, when, and whether they claimed organizational authority
 - **Timestamps** _(collapsed)_
 
-!!! tip "Stakeholder and Campaign look like empty boxes"
-Those two fields show a record's ID number next to a magnifying glass, rather
-than a dropdown. Click the magnifying glass to look up or change the record.
-You will almost never need to change either one.
+The submission details and email-verification fields are read-only. They preserve
+what the endorser submitted and what the verification process recorded. If any of
+them are wrong, record the problem in **Admin notes** and reject the endorsement;
+do not rewrite the source record.
 
 Then work through this mentally:
 

--- a/backend/coalition/endorsements/admin.py
+++ b/backend/coalition/endorsements/admin.py
@@ -49,9 +49,13 @@ class EndorsementAdmin(HelpLinkAdminMixin, admin.ModelAdmin):
         "campaign__title",
         "statement",
     )
-    raw_id_fields = ("stakeholder", "campaign")
     ordering = ("-created_at",)
     readonly_fields = (
+        "stakeholder",
+        "campaign",
+        "statement",
+        "public_display",
+        "email_verified",
         "verification_token",
         "verification_sent_at",
         "verified_at",

--- a/backend/coalition/endorsements/admin.py
+++ b/backend/coalition/endorsements/admin.py
@@ -139,6 +139,9 @@ class EndorsementAdmin(HelpLinkAdminMixin, admin.ModelAdmin):
         "remove_from_display",
     ]
 
+    def has_add_permission(self, request: HttpRequest) -> bool:  # noqa: ARG002
+        return False
+
     @admin.display(description="Name", ordering="stakeholder__last_name")
     def stakeholder_name(self, obj: Endorsement) -> str:
         return obj.stakeholder.name

--- a/backend/coalition/endorsements/tests/test_admin.py
+++ b/backend/coalition/endorsements/tests/test_admin.py
@@ -119,6 +119,12 @@ class EndorsementAdminTest(BaseTestCase):
             "admin_notes",
         }
 
+    def test_admin_creation_is_disabled(self) -> None:
+        request = HttpRequest()
+        request.user = self.user
+
+        assert self.admin.has_add_permission(request) is False
+
     def test_view_only_staff_cannot_access_mutating_actions(self) -> None:
         viewer = User.objects.create_user(username="endorsement-viewer", is_staff=True)
         viewer.user_permissions.add(

--- a/backend/coalition/endorsements/tests/test_admin.py
+++ b/backend/coalition/endorsements/tests/test_admin.py
@@ -84,9 +84,40 @@ class EndorsementAdminTest(BaseTestCase):
         assert ("reviewed_at", EmptyFieldListFilter) in self.admin.list_filter
         assert ("reviewed_by", EmptyFieldListFilter) not in self.admin.list_filter
 
-    def test_review_metadata_is_readonly(self) -> None:
-        assert {"reviewed_by", "reviewed_at"}.issubset(self.admin.readonly_fields)
-        assert "reviewed_by" not in self.admin.raw_id_fields
+    def test_submission_and_automated_fields_are_readonly(self) -> None:
+        expected_readonly_fields = {
+            "stakeholder",
+            "campaign",
+            "statement",
+            "public_display",
+            "email_verified",
+            "verification_token",
+            "verification_sent_at",
+            "verified_at",
+            "terms_accepted",
+            "terms_accepted_at",
+            "org_authorized",
+            "reviewed_by",
+            "reviewed_at",
+            "created_at",
+            "updated_at",
+            "verification_link",
+        }
+
+        assert expected_readonly_fields.issubset(self.admin.readonly_fields)
+        assert self.admin.raw_id_fields == ()
+
+    def test_only_moderation_fields_are_editable_on_change_form(self) -> None:
+        request = HttpRequest()
+        request.user = self.user
+
+        form_class = self.admin.get_form(request, self.endorsement)
+
+        assert set(form_class.base_fields) == {
+            "status",
+            "display_publicly",
+            "admin_notes",
+        }
 
     def test_view_only_staff_cannot_access_mutating_actions(self) -> None:
         viewer = User.objects.create_user(username="endorsement-viewer", is_staff=True)


### PR DESCRIPTION
## Summary

- make submitted endorsement identity, content, consent, and email-verification fields read-only in Django admin
- leave only status, public-display approval, and internal admin notes editable
- update the in-admin review guide to explain the immutable source record
- add regression coverage for both the read-only configuration and the rendered change form

## Why

The endorsement change form exposed source-of-truth fields that staff should inspect but never rewrite. That allowed an administrator to relink an endorsement, alter the endorser's statement or consent, or directly modify verification state. Restricting the form to moderation-owned fields preserves the submitted record and makes the workflow boundary explicit.

## Impact

Staff can continue approving or rejecting endorsements, controlling public display, and recording internal notes. Submitted and automatically recorded fields are now displayed as read-only values.

## Validation

- `pytest coalition/endorsements/tests -q --no-cov` — 131 passed
- endorsement admin and admin-help integration tests — 44 passed, 191 subtests passed
- `ruff format --check` and `ruff check` on changed Python files
- Prettier check on the updated admin-help Markdown
- `git diff --check`