### PR TITLE
fix(admin): omit empty stakeholder organization

### DIFF
--- a/backend/coalition/legal/admin.py
+++ b/backend/coalition/legal/admin.py
@@ -87,7 +87,9 @@ class TermsAcceptanceAdmin(admin.ModelAdmin):
     def endorsement_stakeholder(self, obj: TermsAcceptance) -> str:
         if obj.endorsement and obj.endorsement.stakeholder:
             stakeholder = obj.endorsement.stakeholder
-            return f"{stakeholder.name} ({stakeholder.organization})"
+            if stakeholder.organization:
+                return f"{stakeholder.name} ({stakeholder.organization})"
+            return stakeholder.name
         return "N/A"
 
     @admin.display(description="Document")

--- a/backend/coalition/legal/tests/test_admin.py
+++ b/backend/coalition/legal/tests/test_admin.py
@@ -2,13 +2,15 @@
 Tests for legal Django admin interface.
 """
 
+from types import SimpleNamespace
+
 from django.contrib.admin.sites import AdminSite
 from django.contrib.auth.models import User
 from django.http import HttpRequest
 from django.test import TestCase
 
-from coalition.legal.admin import LegalDocumentAdmin
-from coalition.legal.models import LegalDocument
+from coalition.legal.admin import LegalDocumentAdmin, TermsAcceptanceAdmin
+from coalition.legal.models import LegalDocument, TermsAcceptance
 
 
 class LegalDocumentAdminTest(TestCase):
@@ -89,3 +91,32 @@ class LegalDocumentAdminTest(TestCase):
                 value = getattr(self.legal_document, field)
                 # Value can be None, but accessing it shouldn't error
                 assert (value is not None) or (value is None)
+
+
+class TermsAcceptanceAdminTest(TestCase):
+    def setUp(self) -> None:
+        self.admin = TermsAcceptanceAdmin(TermsAcceptance, AdminSite())
+
+    def test_stakeholder_label_omits_parentheses_without_organization(self) -> None:
+        acceptance = SimpleNamespace(
+            endorsement=SimpleNamespace(
+                stakeholder=SimpleNamespace(name="Leila Hadj-Chikh", organization=""),
+            ),
+        )
+
+        assert self.admin.endorsement_stakeholder(acceptance) == "Leila Hadj-Chikh"
+
+    def test_stakeholder_label_includes_organization_when_present(self) -> None:
+        acceptance = SimpleNamespace(
+            endorsement=SimpleNamespace(
+                stakeholder=SimpleNamespace(
+                    name="Leila Hadj-Chikh",
+                    organization="Coalition Builder",
+                ),
+            ),
+        )
+
+        assert (
+            self.admin.endorsement_stakeholder(acceptance)
+            == "Leila Hadj-Chikh (Coalition Builder)"
+        )


### PR DESCRIPTION
## Summary

- omit empty parentheses from stakeholder names in the Terms Acceptance admin
- preserve organization names in parentheses when present
- add regression coverage for both display cases

## Root cause

The admin formatter always interpolated the optional organization field inside parentheses, so stakeholders without an organization were rendered with a trailing `()`.

## Impact

Stakeholder names in the admin now display cleanly when no organization is recorded, without changing labels for stakeholders that do have an organization.

## Validation

- `poetry run pytest coalition/legal/tests/test_admin.py --no-cov` (6 passed)
- `poetry run ruff format --check coalition/legal/admin.py coalition/legal/tests/test_admin.py`
- `poetry run ruff check coalition/legal/admin.py coalition/legal/tests/test_admin.py`
- `poetry run mypy coalition/legal/admin.py coalition/legal/tests/test_admin.py --config-file pyproject.toml`