### PR TITLE
fix: Terraform deployment cleanup permissions

### DIFF
--- a/terraform/environments/dev/main.tf
+++ b/terraform/environments/dev/main.tf
@@ -286,6 +286,6 @@ module "github_oidc" {
   enable_infrastructure_policy  = true
   resource_prefix               = var.prefix
   additional_iam_prefixes       = ["coalition"]
-  additional_s3_bucket_prefixes = ["coalition"]
+  additional_s3_bucket_prefixes = ["coalition-dev-assets"]
   peering_account_ids           = [var.shared_account_id]
 }

--- a/terraform/environments/dev/main.tf
+++ b/terraform/environments/dev/main.tf
@@ -282,9 +282,10 @@ module "github_oidc" {
     "repo:${var.github_repo}:pull_request",
   ]
 
-  enable_terraform_policy      = true
-  enable_infrastructure_policy = true
-  resource_prefix              = var.prefix
-  additional_iam_prefixes      = ["coalition"]
-  peering_account_ids          = [var.shared_account_id]
+  enable_terraform_policy       = true
+  enable_infrastructure_policy  = true
+  resource_prefix               = var.prefix
+  additional_iam_prefixes       = ["coalition"]
+  additional_s3_bucket_prefixes = ["coalition"]
+  peering_account_ids           = [var.shared_account_id]
 }

--- a/terraform/environments/prod/main.tf
+++ b/terraform/environments/prod/main.tf
@@ -396,9 +396,10 @@ module "github_oidc" {
     "repo:${var.github_repo}:ref:refs/heads/main",
   ]
 
-  enable_terraform_policy      = true
-  enable_infrastructure_policy = true
-  resource_prefix              = var.prefix
-  additional_iam_prefixes      = ["coalition"]
-  peering_account_ids          = [var.shared_account_id]
+  enable_terraform_policy       = true
+  enable_infrastructure_policy  = true
+  resource_prefix               = var.prefix
+  additional_iam_prefixes       = ["coalition"]
+  additional_s3_bucket_prefixes = ["coalition"]
+  peering_account_ids           = [var.shared_account_id]
 }

--- a/terraform/environments/prod/main.tf
+++ b/terraform/environments/prod/main.tf
@@ -400,6 +400,6 @@ module "github_oidc" {
   enable_infrastructure_policy  = true
   resource_prefix               = var.prefix
   additional_iam_prefixes       = ["coalition"]
-  additional_s3_bucket_prefixes = ["coalition"]
+  additional_s3_bucket_prefixes = ["coalition-production-assets"]
   peering_account_ids           = [var.shared_account_id]
 }

--- a/terraform/modules/github-oidc/main.tf
+++ b/terraform/modules/github-oidc/main.tf
@@ -187,12 +187,16 @@ resource "aws_iam_role_policy" "infrastructure" {
             "s3:PutObjectAcl",
             "s3:PutBucketAcl",
           ]
-          Resource = [
-            "arn:aws:s3:::${var.resource_prefix}-*",
-            "arn:aws:s3:::${var.resource_prefix}-*/*",
-            "arn:aws:s3:::coalition-terraform-state-*",
-            "arn:aws:s3:::coalition-terraform-state-*/*",
-          ]
+          Resource = concat(
+            [
+              "arn:aws:s3:::${var.resource_prefix}-*",
+              "arn:aws:s3:::${var.resource_prefix}-*/*",
+              "arn:aws:s3:::coalition-terraform-state-*",
+              "arn:aws:s3:::coalition-terraform-state-*/*",
+            ],
+            [for prefix in var.additional_s3_bucket_prefixes : "arn:aws:s3:::${prefix}-*"],
+            [for prefix in var.additional_s3_bucket_prefixes : "arn:aws:s3:::${prefix}-*/*"],
+          )
         },
         {
           Sid    = "Route53"
@@ -247,6 +251,7 @@ resource "aws_iam_role_policy" "infrastructure" {
             "iam:ListUserPolicies",
             "iam:ListUserTags",
             "iam:ListAccessKeys",
+            "iam:ListGroupsForUser",
             "iam:SimulatePrincipalPolicy",
           ]
           Resource = "*"

--- a/terraform/modules/github-oidc/tests/deployment_permissions.tftest.hcl
+++ b/terraform/modules/github-oidc/tests/deployment_permissions.tftest.hcl
@@ -19,7 +19,7 @@ variables {
   additional_s3_bucket_prefixes = ["legacy", "archive"]
 }
 
-run "zappa_cloudformation_operations_are_allowed" {
+run "deployment_permissions_are_allowed" {
   command = plan
 
   assert {

--- a/terraform/modules/github-oidc/tests/deployment_permissions.tftest.hcl
+++ b/terraform/modules/github-oidc/tests/deployment_permissions.tftest.hcl
@@ -16,7 +16,7 @@ variables {
   enable_terraform_policy       = false
   enable_infrastructure_policy  = true
   resource_prefix               = "example"
-  additional_s3_bucket_prefixes = ["coalition"]
+  additional_s3_bucket_prefixes = ["legacy", "archive"]
 }
 
 run "zappa_cloudformation_operations_are_allowed" {
@@ -58,10 +58,12 @@ run "zappa_cloudformation_operations_are_allowed" {
   assert {
     condition = length([
       for statement in jsondecode(aws_iam_role_policy.infrastructure[0].policy).Statement : statement
-      if statement.Sid == "S3Mutate" && alltrue([
+      if statement.Sid == "S3Mutate" && statement.Effect == "Allow" && alltrue([
         contains(statement.Action, "s3:PutLifecycleConfiguration"),
-        contains(statement.Resource, "arn:aws:s3:::coalition-*"),
-        contains(statement.Resource, "arn:aws:s3:::coalition-*/*"),
+        contains(statement.Resource, "arn:aws:s3:::legacy-*"),
+        contains(statement.Resource, "arn:aws:s3:::legacy-*/*"),
+        contains(statement.Resource, "arn:aws:s3:::archive-*"),
+        contains(statement.Resource, "arn:aws:s3:::archive-*/*"),
       ])
     ]) == 1
     error_message = "The GitHub Actions role must manage lifecycle rules for every configured application bucket prefix."

--- a/terraform/modules/github-oidc/tests/deployment_permissions.tftest.hcl
+++ b/terraform/modules/github-oidc/tests/deployment_permissions.tftest.hcl
@@ -9,13 +9,14 @@ mock_provider "aws" {
 }
 
 variables {
-  environment                  = "prod"
-  create_oidc_provider         = false
-  existing_oidc_provider_arn   = "arn:aws:iam::123456789012:oidc-provider/token.actions.githubusercontent.com"
-  github_subjects              = ["repo:example/project:environment:prod"]
-  enable_terraform_policy      = false
-  enable_infrastructure_policy = true
-  resource_prefix              = "example"
+  environment                   = "prod"
+  create_oidc_provider          = false
+  existing_oidc_provider_arn    = "arn:aws:iam::123456789012:oidc-provider/token.actions.githubusercontent.com"
+  github_subjects               = ["repo:example/project:environment:prod"]
+  enable_terraform_policy       = false
+  enable_infrastructure_policy  = true
+  resource_prefix               = "example"
+  additional_s3_bucket_prefixes = ["coalition"]
 }
 
 run "zappa_cloudformation_operations_are_allowed" {
@@ -44,5 +45,25 @@ run "zappa_cloudformation_operations_are_allowed" {
       if statement.Sid == "IAMReadOnly" && contains(statement.Action, "iam:SimulatePrincipalPolicy")
     ]) == 1
     error_message = "The GitHub Actions role must be able to verify the Lambda execution role before deployment."
+  }
+
+  assert {
+    condition = length([
+      for statement in jsondecode(aws_iam_role_policy.infrastructure[0].policy).Statement : statement
+      if statement.Sid == "IAMReadOnly" && contains(statement.Action, "iam:ListGroupsForUser")
+    ]) == 1
+    error_message = "The GitHub Actions role must be able to inspect IAM user groups before Terraform deletes a user."
+  }
+
+  assert {
+    condition = length([
+      for statement in jsondecode(aws_iam_role_policy.infrastructure[0].policy).Statement : statement
+      if statement.Sid == "S3Mutate" && alltrue([
+        contains(statement.Action, "s3:PutLifecycleConfiguration"),
+        contains(statement.Resource, "arn:aws:s3:::coalition-*"),
+        contains(statement.Resource, "arn:aws:s3:::coalition-*/*"),
+      ])
+    ]) == 1
+    error_message = "The GitHub Actions role must manage lifecycle rules for every configured application bucket prefix."
   }
 }

--- a/terraform/modules/github-oidc/variables.tf
+++ b/terraform/modules/github-oidc/variables.tf
@@ -66,3 +66,9 @@ variable "additional_iam_prefixes" {
   type        = list(string)
   default     = []
 }
+
+variable "additional_s3_bucket_prefixes" {
+  description = "Additional S3 bucket prefixes managed by the infrastructure deployment role"
+  type        = list(string)
+  default     = []
+}


### PR DESCRIPTION
## Summary

- allow Terraform's IAM user deletion preflight to list user groups
- let deployment roles manage application S3 buckets whose legacy `coalition-*` names fall outside the environment-configured resource prefix
- add native Terraform coverage for both permissions

## Root cause

The production rollout could delete the SMTP user's policy and access key but failed when the AWS provider called `iam:ListGroupsForUser` before deleting the empty user. The development rollout separately failed on `s3:PutLifecycleConfiguration` because the action was allowed but its resource scope matched only the configured primary prefix, while the managed assets bucket is named `coalition-dev-assets-*`.

Both environments were safely reconciled with administrator credentials and now produce no-change plans. This PR makes future workflow-driven cleanup complete without manual intervention.

## Security impact

The added access remains bounded: `iam:ListGroupsForUser` is read-only, and S3 mutation access is limited to explicitly configured bucket-name prefixes. Development grants the additional access only to `coalition-dev-assets-*`, and production grants it only to `coalition-production-assets-*`.

## Validation

- `terraform -chdir=terraform/modules/github-oidc test`
- `terraform -chdir=terraform/modules/github-oidc validate`
- `terraform -chdir=terraform/environments/prod validate`
- `terraform -chdir=terraform/environments/dev validate`
- `terraform fmt -check -recursive terraform`
- `tflint --chdir=terraform --recursive`
- [production no-change run](https://github.com/lhadjchikh/coalition-builder/actions/runs/31338436177)
- [development no-change run](https://github.com/lhadjchikh/coalition-builder/actions/runs/31338648027)
