### PR TITLE
fix(frontend): focus endorsement submission errors

### DIFF
--- a/frontend/components/EndorsementForm.tsx
+++ b/frontend/components/EndorsementForm.tsx
@@ -1,4 +1,5 @@
 import React, {
+  useEffect,
   useState,
   useRef,
   forwardRef,
@@ -122,6 +123,19 @@ const EndorsementForm = forwardRef<EndorsementFormRef, EndorsementFormProps>(
     const formRef = useRef<HTMLFormElement>(null);
     const typeSelectRef = useRef<HTMLSelectElement>(null);
     const submitButtonRef = useRef<HTMLButtonElement>(null);
+    const errorMessageRef = useRef<HTMLDivElement>(null);
+
+    useEffect(() => {
+      if (!error || !errorMessageRef.current) {
+        return;
+      }
+
+      errorMessageRef.current.scrollIntoView({
+        behavior: "smooth",
+        block: "center",
+      });
+      errorMessageRef.current.focus({ preventScroll: true });
+    }, [error]);
 
     // Expose methods to parent component
     useImperativeHandle(
@@ -324,7 +338,13 @@ const EndorsementForm = forwardRef<EndorsementFormRef, EndorsementFormProps>(
         )}
 
         {error && (
-          <div className="error-message" data-testid="error-message">
+          <div
+            className="error-message"
+            data-testid="error-message"
+            ref={errorMessageRef}
+            role="alert"
+            tabIndex={-1}
+          >
             <p>Error: {error}</p>
           </div>
         )}

--- a/frontend/components/__tests__/EndorsementForm.test.tsx
+++ b/frontend/components/__tests__/EndorsementForm.test.tsx
@@ -471,6 +471,12 @@ describe("EndorsementForm", () => {
       (API.createEndorsement as jest.Mock).mockRejectedValue(
         new Error("Submission failed")
       );
+      const scrollIntoViewMock = jest.fn();
+      Object.defineProperty(HTMLElement.prototype, "scrollIntoView", {
+        configurable: true,
+        value: scrollIntoViewMock,
+        writable: true,
+      });
 
       render(<EndorsementForm campaign={mockCampaign} />);
 
@@ -492,8 +498,14 @@ describe("EndorsementForm", () => {
       fireEvent.click(screen.getByTestId("terms-checkbox"));
       fireEvent.click(screen.getByTestId("submit-button"));
 
-      await waitFor(() => {
-        expect(screen.getByTestId("error-message")).toBeInTheDocument();
+      const errorMessage = await screen.findByTestId("error-message");
+
+      expect(errorMessage).toHaveAttribute("role", "alert");
+      expect(errorMessage).toHaveAttribute("tabindex", "-1");
+      expect(errorMessage).toHaveFocus();
+      expect(scrollIntoViewMock).toHaveBeenCalledWith({
+        behavior: "smooth",
+        block: "center",
       });
 
       // Should not show social share buttons


### PR DESCRIPTION
## Summary

- scroll endorsement submission errors into view after a failed request
- move keyboard focus to the error summary without triggering a second scroll
- expose the error as an accessible alert and cover the complete interaction with a regression test

## Root cause

The endorsement form renders submission errors above a long form while the submit button is at the bottom. A failed request therefore leaves the user at the submit button with the error outside the viewport, making the failure easy to miss.

## Impact

Users now see the failure immediately without a modal interrupting or clearing the form. Keyboard and screen-reader users are also directed to the alert, while all entered values remain available for correction or retry.

## Validation

- `CI=true npm test -- --runInBand` — 526 tests passed
- `npm run typecheck`
- `npm run lint`
- `npm run format:check`
