### PR TITLE
fix(frontend): center endorsement confirmation modal

### DIFF
--- a/frontend/__tests__/EndorsementConfirmationDialogStyles.test.ts
+++ b/frontend/__tests__/EndorsementConfirmationDialogStyles.test.ts
@@ -1,0 +1,23 @@
+import fs from "fs";
+import path from "path";
+
+describe("Endorsement confirmation dialog styles", () => {
+  it("centers the dialog in the viewport", () => {
+    const stylesheetPath = path.join(__dirname, "../styles/Endorsements.css");
+    const stylesheet = document.createElement("style");
+    stylesheet.textContent = fs.readFileSync(stylesheetPath, "utf-8");
+    document.head.appendChild(stylesheet);
+
+    const dialog = document.createElement("dialog");
+    dialog.className = "success-message confirmation-dialog";
+    document.body.appendChild(dialog);
+
+    const dialogStyles = window.getComputedStyle(dialog);
+    expect(dialogStyles.position).toBe("fixed");
+    expect(dialogStyles.inset).toBe("0");
+    expect(dialogStyles.marginTop).toBe("auto");
+    expect(dialogStyles.marginLeft).toBe("auto");
+    expect(dialogStyles.marginRight).toBe("auto");
+    expect(dialogStyles.marginBottom).toBe("auto");
+  });
+});

--- a/frontend/styles/Endorsements.css
+++ b/frontend/styles/Endorsements.css
@@ -1226,15 +1226,6 @@ legend.form-label {
 }
 
 /* Success Message */
-.confirmation-dialog {
-  position: relative;
-  width: min(36rem, calc(100% - 2rem));
-  max-height: calc(100vh - 2rem);
-  overflow-y: auto;
-  box-sizing: border-box;
-  box-shadow: 0 24px 60px rgba(15, 23, 42, 0.35);
-}
-
 .confirmation-dialog::backdrop {
   background: rgba(15, 23, 42, 0.65);
 }
@@ -1289,6 +1280,17 @@ legend.form-label {
 
 .success-message p {
   margin: 0.5rem 0;
+}
+
+.success-message.confirmation-dialog {
+  position: fixed;
+  inset: 0;
+  width: min(36rem, calc(100% - 2rem));
+  max-height: calc(100vh - 2rem);
+  margin: auto;
+  overflow-y: auto;
+  box-sizing: border-box;
+  box-shadow: 0 24px 60px rgba(15, 23, 42, 0.35);
 }
 
 .share-endorsement-section {


### PR DESCRIPTION
## Summary

- Center the endorsement confirmation dialog horizontally and vertically within the viewport.
- Add a regression test covering fixed positioning, viewport inset, and automatic margins.

## Testing

- npm test -- --runInBand components/__tests__/EndorsementForm.test.tsx __tests__/EndorsementConfirmationDialogStyles.test.ts
- npm run typecheck
- npm run lint
- npx prettier --check __tests__/EndorsementConfirmationDialogStyles.test.ts styles/Endorsements.css