### PR TITLE
feat(frontend): redirect admin route to backend

### DIFF
--- a/frontend/__tests__/next-config-rewrites.test.js
+++ b/frontend/__tests__/next-config-rewrites.test.js
@@ -48,28 +48,29 @@ describe("next.config.js redirects", () => {
   });
 
   it("normalizes the production API URL before appending /admin/", async () => {
-    const originalApiUrl = process.env.API_URL;
-    process.env.API_URL = "https://api.landandbay.org/";
-    jest.resetModules();
+    const productionRedirects = await loadRedirectsForApiUrls(
+      "https://api.landandbay.org/",
+      "https://api.landandbay.org/"
+    );
 
-    try {
-      // eslint-disable-next-line @typescript-eslint/no-require-imports
-      const productionConfig = require("../next.config.js");
-      const productionRedirects = await productionConfig.redirects();
+    expect(productionRedirects).toContainEqual({
+      source: "/admin",
+      destination: "https://api.landandbay.org/admin/",
+      permanent: false,
+    });
+  });
 
-      expect(productionRedirects).toContainEqual({
-        source: "/admin",
-        destination: "https://api.landandbay.org/admin/",
-        permanent: false,
-      });
-    } finally {
-      if (originalApiUrl === undefined) {
-        delete process.env.API_URL;
-      } else {
-        process.env.API_URL = originalApiUrl;
-      }
-      jest.resetModules();
-    }
+  it("uses the browser-reachable API URL when server and public URLs differ", async () => {
+    const developmentRedirects = await loadRedirectsForApiUrls(
+      "http://api:8000",
+      "http://localhost:8000"
+    );
+
+    expect(developmentRedirects).toContainEqual({
+      source: "/admin",
+      destination: "http://localhost:8000/admin/",
+      permanent: false,
+    });
   });
 });
 
@@ -78,3 +79,30 @@ describe("next.config.js build type checking", () => {
     expect(nextConfig.typescript.tsconfigPath).toBe("tsconfig.build.json");
   });
 });
+
+async function loadRedirectsForApiUrls(apiUrl, publicApiUrl) {
+  const originalApiUrl = process.env.API_URL;
+  const originalPublicApiUrl = process.env.NEXT_PUBLIC_API_URL;
+  process.env.API_URL = apiUrl;
+  process.env.NEXT_PUBLIC_API_URL = publicApiUrl;
+  jest.resetModules();
+
+  try {
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const configuredNextConfig = require("../next.config.js");
+    return await configuredNextConfig.redirects();
+  } finally {
+    restoreEnvironmentVariable("API_URL", originalApiUrl);
+    restoreEnvironmentVariable("NEXT_PUBLIC_API_URL", originalPublicApiUrl);
+    jest.resetModules();
+  }
+}
+
+function restoreEnvironmentVariable(name, originalValue) {
+  if (originalValue === undefined) {
+    delete process.env[name];
+    return;
+  }
+
+  process.env[name] = originalValue;
+}

--- a/frontend/__tests__/next-config-rewrites.test.js
+++ b/frontend/__tests__/next-config-rewrites.test.js
@@ -49,13 +49,13 @@ describe("next.config.js redirects", () => {
 
   it("normalizes the production API URL before appending /admin/", async () => {
     const productionRedirects = await loadRedirectsForApiUrls(
-      "https://api.landandbay.org/",
-      "https://api.landandbay.org/"
+      "https://api.example.org/",
+      "https://api.example.org/"
     );
 
     expect(productionRedirects).toContainEqual({
       source: "/admin",
-      destination: "https://api.landandbay.org/admin/",
+      destination: "https://api.example.org/admin/",
       permanent: false,
     });
   });

--- a/frontend/__tests__/next-config-rewrites.test.js
+++ b/frontend/__tests__/next-config-rewrites.test.js
@@ -32,6 +32,47 @@ describe("next.config.js rewrites", () => {
   });
 });
 
+describe("next.config.js redirects", () => {
+  let redirects;
+
+  beforeAll(async () => {
+    redirects = await nextConfig.redirects();
+  });
+
+  it("redirects /admin to the backend admin page", () => {
+    expect(redirects).toContainEqual({
+      source: "/admin",
+      destination: `${nextConfig.env.API_URL.replace(/\/+$/, "")}/admin/`,
+      permanent: false,
+    });
+  });
+
+  it("normalizes the production API URL before appending /admin/", async () => {
+    const originalApiUrl = process.env.API_URL;
+    process.env.API_URL = "https://api.landandbay.org/";
+    jest.resetModules();
+
+    try {
+      // eslint-disable-next-line @typescript-eslint/no-require-imports
+      const productionConfig = require("../next.config.js");
+      const productionRedirects = await productionConfig.redirects();
+
+      expect(productionRedirects).toContainEqual({
+        source: "/admin",
+        destination: "https://api.landandbay.org/admin/",
+        permanent: false,
+      });
+    } finally {
+      if (originalApiUrl === undefined) {
+        delete process.env.API_URL;
+      } else {
+        process.env.API_URL = originalApiUrl;
+      }
+      jest.resetModules();
+    }
+  });
+});
+
 describe("next.config.js build type checking", () => {
   it("uses the test-excluding TypeScript build configuration", () => {
     expect(nextConfig.typescript.tsconfigPath).toBe("tsconfig.build.json");

--- a/frontend/components/Footer.tsx
+++ b/frontend/components/Footer.tsx
@@ -13,9 +13,6 @@ interface FooterProps {
   className?: string;
 }
 
-const getAdminUrl = (apiBaseUrl: string | undefined): string =>
-  `${apiBaseUrl?.replace(/\/+$/, "") ?? ""}/admin/`;
-
 const Footer: React.FC<FooterProps> = ({
   orgInfo,
   showSocialLinks = true,
@@ -27,7 +24,6 @@ const Footer: React.FC<FooterProps> = ({
   }
 
   const currentYear = new Date().getFullYear();
-  const adminUrl = getAdminUrl(process.env.NEXT_PUBLIC_API_URL);
 
   return (
     <footer className={className || "bg-gray-900"}>
@@ -163,7 +159,7 @@ const Footer: React.FC<FooterProps> = ({
                   </li>
                   <li>
                     <Link
-                      href={adminUrl}
+                      href="/admin"
                       className="text-gray-400 hover:text-white transition-colors duration-200 hover:underline text-sm sm:text-base"
                     >
                       Admin Login

--- a/frontend/components/__tests__/Footer.test.tsx
+++ b/frontend/components/__tests__/Footer.test.tsx
@@ -59,17 +59,6 @@ jest.mock("next/link", () => {
 });
 
 describe("Footer navigation", () => {
-  const originalApiUrl = process.env.NEXT_PUBLIC_API_URL;
-
-  afterEach(() => {
-    if (originalApiUrl === undefined) {
-      delete process.env.NEXT_PUBLIC_API_URL;
-      return;
-    }
-
-    process.env.NEXT_PUBLIC_API_URL = originalApiUrl;
-  });
-
   it("renders Terms of Use and Privacy Policy links", () => {
     render(<Footer orgInfo={mockHomepage} />);
 
@@ -100,26 +89,10 @@ describe("Footer navigation", () => {
     expect(screen.getByText("Contact")).toHaveAttribute("href", "/contact");
   });
 
-  it("builds the production admin link from the configured API URL", () => {
-    process.env.NEXT_PUBLIC_API_URL = "https://api.landandbay.org";
-
+  it("links Admin Login through the frontend admin route", () => {
     render(<Footer orgInfo={mockHomepage} />);
 
-    expect(screen.getByText("Admin Login")).toHaveAttribute(
-      "href",
-      "https://api.landandbay.org/admin/"
-    );
-  });
-
-  it("builds the development admin link without a duplicate slash", () => {
-    process.env.NEXT_PUBLIC_API_URL = "https://test-api.landandbay.org/";
-
-    render(<Footer orgInfo={mockHomepage} />);
-
-    expect(screen.getByText("Admin Login")).toHaveAttribute(
-      "href",
-      "https://test-api.landandbay.org/admin/"
-    );
+    expect(screen.getByText("Admin Login")).toHaveAttribute("href", "/admin");
   });
 
   it("renders organization name and tagline", () => {

--- a/frontend/next.config.js
+++ b/frontend/next.config.js
@@ -5,7 +5,8 @@ const API_BASE_URL =
   process.env.API_URL ||
   process.env.NEXT_PUBLIC_API_URL ||
   "http://localhost:8000";
-const ADMIN_PAGE_URL = `${API_BASE_URL.replace(/\/+$/, "")}/admin/`;
+const BROWSER_API_BASE_URL = process.env.NEXT_PUBLIC_API_URL || API_BASE_URL;
+const ADMIN_PAGE_URL = `${BROWSER_API_BASE_URL.replace(/\/+$/, "")}/admin/`;
 
 /** @type {import('next').NextConfig} */
 const nextConfig = {

--- a/frontend/next.config.js
+++ b/frontend/next.config.js
@@ -5,6 +5,7 @@ const API_BASE_URL =
   process.env.API_URL ||
   process.env.NEXT_PUBLIC_API_URL ||
   "http://localhost:8000";
+const ADMIN_PAGE_URL = `${API_BASE_URL.replace(/\/+$/, "")}/admin/`;
 
 /** @type {import('next').NextConfig} */
 const nextConfig = {
@@ -26,6 +27,16 @@ const nextConfig = {
   env: {
     API_URL: API_BASE_URL,
     NEXT_PUBLIC_API_URL: API_BASE_URL,
+  },
+
+  async redirects() {
+    return [
+      {
+        source: "/admin",
+        destination: ADMIN_PAGE_URL,
+        permanent: false,
+      },
+    ];
   },
 
   // Rewrites for API calls - routes relative paths to backend.


### PR DESCRIPTION
This PR gives visitors a stable `/admin` entry point on the frontend while ensuring the browser is redirected to the publicly reachable backend rather than an internal server address.

## What this changes

The [Next.js configuration](https://github.com/lhadjchikh/coalition-builder/blob/lhadjchikh/redirect-admin-page/frontend/next.config.js) adds a temporary redirect from `/admin` to the configured public API's `/admin/` page. It normalizes trailing slashes and falls back to the server API URL when no separate public URL is configured.

The [footer](https://github.com/lhadjchikh/coalition-builder/blob/lhadjchikh/redirect-admin-page/frontend/components/Footer.tsx) now links to the local `/admin` route, leaving the backend destination in one configuration point.

The [redirect tests](https://github.com/lhadjchikh/coalition-builder/blob/lhadjchikh/redirect-admin-page/frontend/__tests__/next-config-rewrites.test.js) cover trailing-slash normalization and environments where browser-facing and server-only API URLs differ. The [footer test](https://github.com/lhadjchikh/coalition-builder/blob/lhadjchikh/redirect-admin-page/frontend/components/__tests__/Footer.test.tsx) verifies the local link.

## Where to focus

### For human reviewers

- Confirm that a temporary redirect is appropriate for the admin entry point.
- Confirm that the public API URL should take precedence for a browser-facing redirect.

### For an AI review agent

- Check URL normalization and fallback behavior across production, preview, and local environments.
- Verify that the tests distinguish public browser addresses from internal server addresses.

## Design notes

**Browser and server API addresses remain distinct.** Server-side rewrites continue using the server API URL, while the external redirect prefers the browser-reachable public URL.

**The redirect is temporary.** A 307 avoids permanently caching a deployment-specific backend destination.

**The footer uses the frontend route.** This removes duplicate admin URL construction from the component.

## Validation

- Full frontend Jest suite: 496 tests passed before the final environment-boundary fix.
- Focused redirect and footer suites after the fix: 14 tests passed.
- ESLint and Prettier checks passed.
- Next.js production builds passed with production-style and split local API URLs.
